### PR TITLE
Correct prime factors function name

### DIFF
--- a/prime-factors/prime_factors.exs
+++ b/prime-factors/prime_factors.exs
@@ -7,8 +7,8 @@ defmodule PrimeFactors do
 
   The prime factors of 'number' will be ordered lowest to highest. 
   """
-  @spec for(pos_integer) :: [pos_integer]
-  def for(number) do
+  @spec factors_for(pos_integer) :: [pos_integer]
+  def factors_for(number) do
 
   end
 end


### PR DESCRIPTION
Hello!

The name of the function in the example and test suite is `factors_for`, but not in the exercise. I've changed this file to match.

Cheers,
Louis