### PR TITLE
bob: tag tests pending

### DIFF
--- a/bob/bob_test.exs
+++ b/bob/bob_test.exs
@@ -5,6 +5,7 @@ else
 end
 
 ExUnit.start
+ExUnit.configure(exclude: :pending)
 
 defmodule TeenagerTest do
   use ExUnit.Case, async: true
@@ -13,56 +14,69 @@ defmodule TeenagerTest do
     assert Teenager.hey("Tom-ay-to, tom-aaaah-to.") == "Whatever."
   end
 
+  @tag :pending
   test "shouting" do
-    # assert Teenager.hey("WATCH OUT!") == "Whoa, chill out!"
+    assert Teenager.hey("WATCH OUT!") == "Whoa, chill out!"
   end
 
+  @tag :pending
   test "asking a question" do
-    # assert Teenager.hey("Does this cryogenic chamber make me look fat?") == "Sure."
+    assert Teenager.hey("Does this cryogenic chamber make me look fat?") == "Sure."
   end
 
+  @tag :pending
   test "talking forcefully" do
-    # assert Teenager.hey("Let's go make out behind the gym!") == "Whatever."
+    assert Teenager.hey("Let's go make out behind the gym!") == "Whatever."
   end
 
+  @tag :pending
   test "talking in capitals" do
-    # assert Teenager.hey("This Isn't Shouting!") == "Whatever."
+    assert Teenager.hey("This Isn't Shouting!") == "Whatever."
   end
 
+  @tag :pending
   test "shouting numbers" do
-    # assert Teenager.hey("1, 2, 3 GO!") == "Whoa, chill out!"
+    assert Teenager.hey("1, 2, 3 GO!") == "Whoa, chill out!"
   end
 
+  @tag :pending
   test "shouting with special characters" do
-    # assert Teenager.hey("ZOMG THE %^*@#$(*^ ZOMBIES ARE COMING!!11!!1!") == "Whoa, chill out!"
+    assert Teenager.hey("ZOMG THE %^*@#$(*^ ZOMBIES ARE COMING!!11!!1!") == "Whoa, chill out!"
   end
 
+  @tag :pending
   test "shouting with no exclamation mark" do
-    # assert Teenager.hey("I HATE YOU") == "Whoa, chill out!"
+    assert Teenager.hey("I HATE YOU") == "Whoa, chill out!"
   end
 
+  @tag :pending
   test "statement containing question mark" do
-    # assert Teenager.hey("Ending with ? means a question.") == "Whatever."
+    assert Teenager.hey("Ending with ? means a question.") == "Whatever."
   end
 
+  @tag :pending
   test "silence" do
-    # assert Teenager.hey("") == "Fine. Be that way!"
+    assert Teenager.hey("") == "Fine. Be that way!"
   end
 
+  @tag :pending
   test "prolonged silence" do
-    # assert Teenager.hey("  ") == "Fine. Be that way!"
+    assert Teenager.hey("  ") == "Fine. Be that way!"
   end
 
+  @tag :pending
   test "only numbers" do
-    # assert Teenager.hey("1, 2, 3") == "Whatever."
+    assert Teenager.hey("1, 2, 3") == "Whatever."
   end
 
+  @tag :pending
   test "question with numbers" do
-    # assert Teenager.hey("4?") == "Sure."
+    assert Teenager.hey("4?") == "Sure."
   end
 
+  @tag :pending
   test "shouting in Russian" do
     # Hopefully this is Russian for "get out"
-    # assert Teenager.hey("УХОДИТЬ") == "Whoa, chill out!"
+    assert Teenager.hey("УХОДИТЬ") == "Whoa, chill out!"
   end
 end


### PR DESCRIPTION
Added an ExUnit tag for pending test cases. This enables excluding tests from the default test suite without commenting out the tests.

With a future release (or building currently from source) of Elixir the number of skipped tests will be visible too (https://github.com/elixir-lang/elixir/pull/2898):

```14 tests, 1 failure, 13 skipped```

This would be a good approach for #47 