### PR TITLE
Fix syntax error in the ETL doctest

### DIFF
--- a/etl/etl.exs
+++ b/etl/etl.exs
@@ -4,7 +4,7 @@ defmodule ETL do
 
   ## Examples
 
-  iex> ETL.transform(%{"a" => ["ABILITY", "AARDVARK"]}, "b" => ["BALLAST", "BEAUTY"]})
+  iex> ETL.transform(%{"a" => ["ABILITY", "AARDVARK"], "b" => ["BALLAST", "BEAUTY"]})
   %{"ability" => "a", "aardvark" => "a", "ballast" => "b", "beauty" =>"b"}
   """
   @spec transform(Dict.t) :: map()


### PR DESCRIPTION
The title says it all: this fixes the error in the doctest.