### PR TITLE
Bring tests and example code up to date with v1.0.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@
 .DS_Store
 tmp
 bin/configlet
-bin/configlet.exe
+bin/configlet*
+deps
+_build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
-language: bash
+language: elixir
 
 script:
   - bin/fetch-configlet
   - bin/configlet .
+  - mix deps.get
+  - EXERCISM_TEST_EXAMPLES=true mix test

--- a/anagram/anagram_test.exs
+++ b/anagram/anagram_test.exs
@@ -15,52 +15,52 @@ defmodule AnagramTest do
   end
 
   test "detect simple anagram" do
-    # matches = Anagram.match "ant", ["tan", "stand", "at"]
-    # assert matches == ["tan"]
+    matches = Anagram.match "ant", ["tan", "stand", "at"]
+    assert matches == ["tan"]
   end
 
   test "detect multiple anagrams" do
-    # matches = Anagram.match "master", ["stream", "pigeon", "maters"]
-    # assert matches == ["stream", "maters"]
+    matches = Anagram.match "master", ["stream", "pigeon", "maters"]
+    assert matches == ["stream", "maters"]
   end
 
   test "do not detect anagram subsets" do
-    # matches = Anagram.match "good", ~w(dog goody)
-    # assert matches == []
+    matches = Anagram.match "good", ~w(dog goody)
+    assert matches == []
   end
 
   test "detect anagram" do
-    # matches = Anagram.match "listen", ~w(enlists google inlets banana)
-    # assert matches == ["inlets"]
+    matches = Anagram.match "listen", ~w(enlists google inlets banana)
+    assert matches == ["inlets"]
   end
 
   test "multiple anagrams" do
-    # matches = Anagram.match "allergy", ~w(gallery ballerina regally clergy largely leading)
-    # assert matches == ["gallery", "regally", "largely"]
+    matches = Anagram.match "allergy", ~w(gallery ballerina regally clergy largely leading)
+    assert matches == ["gallery", "regally", "largely"]
   end
 
   test "anagrams must use all letters exactly once" do
-    # matches = Anagram.match "patter", ["tapper"]
-    # assert matches == []
+    matches = Anagram.match "patter", ["tapper"]
+    assert matches == []
   end
 
   test "detect anagrams with case-insensitive subject" do
-    # matches = Anagram.match "Orchestra", ~w(cashregister carthorse radishes)
-    # assert matches == ["carthorse"]
+    matches = Anagram.match "Orchestra", ~w(cashregister carthorse radishes)
+    assert matches == ["carthorse"]
   end
 
   test "detect anagrams with case-insensitive candidate" do
-    # matches = Anagram.match "orchestra", ~w(cashregister Carthorse radishes)
-    # assert matches == ["Carthorse"]
+    matches = Anagram.match "orchestra", ~w(cashregister Carthorse radishes)
+    assert matches == ["Carthorse"]
   end
 
   test "anagrams must not be the source word" do
-    # matches = Anagram.match "corn", ["corn", "dark", "Corn", "rank", "CORN", "cron", "park"]
-    # assert matches == ["cron"]
+    matches = Anagram.match "corn", ["corn", "dark", "Corn", "rank", "CORN", "cron", "park"]
+    assert matches == ["cron"]
   end
 
   test "do not detect words based on checksum" do
-    # matches = Anagram.match "mass", ["last"]
-    # assert matches == []
+    matches = Anagram.match "mass", ["last"]
+    assert matches == []
   end
 end

--- a/bank-account/bank_account_test.exs
+++ b/bank-account/bank_account_test.exs
@@ -28,7 +28,6 @@ defmodule BankAccountTest do
 
   setup do
     account = BankAccount.open_bank()
-    on_exit fn -> BankAccount.close_bank(account) end
     { :ok, [ account: account ] }
   end
 
@@ -55,13 +54,5 @@ defmodule BankAccountTest do
       1000 -> flunk("Timeout") 
     end
     assert BankAccount.balance(context[:account]) == 20
-  end
-
-  ## Workarounds
-
-  # This deals with the deprecation of the send operator.
-  # It makes this code work both pre-0.12.2 and post-0.12.3
-  unless { :send, 2 } in Kernel.__info__(:functions) do
-    defp send(to, what), do: to <- what
   end
 end

--- a/bob/bob.exs
+++ b/bob/bob.exs
@@ -1,6 +1,7 @@
 defmodule Teenager do
   def hey(input) do
     cond do
+        true -> raise "Your implementation goes here"
 
     end
   end

--- a/config.json
+++ b/config.json
@@ -47,7 +47,9 @@
 
   ],
   "ignored": [
-    "docs"
+    "docs",
+    "deps",
+    "test"
   ],
   "foregone": [
     "robot-name"

--- a/forth/forth.exs
+++ b/forth/forth.exs
@@ -25,20 +25,24 @@ defmodule Forth do
   def format_stack(ev) do
   
   end
-end
 
-defexception Forth.StackUnderflow do
-  def message(_), do: "stack underflow"
-end
+  defmodule StackUnderflow do
+    defexception []
+    def exception(_), do: "stack underflow"
+  end
 
-defexception Forth.InvalidWord, word: nil do
-  def message(e), do: "invalid word: #{inspect e.word}"
-end
+  defmodule InvalidWord do
+    defexception [:word]
+    def exception(e), do: "invalid word: #{inspect e.word}"
+  end
 
-defexception Forth.UnknownWord, word: nil do
-  def message(e), do: "unknown word: #{inspect e.word}"
-end
+  defmodule UnknownWord do
+    defexception [:word]
+    def exception(e), do: "unknown word: #{inspect e.word}"
+  end
 
-defexception Forth.DivisionByZero do
-  def message(_), do: "division by zero"
+  defmodule DivisionByZero do
+    defexception []
+    def exception(_), do: "division by zero"
+  end
 end

--- a/forth/forth_test.exs
+++ b/forth/forth_test.exs
@@ -24,7 +24,7 @@ defmodule ForthTest do
   test "non-word characters are separators" do
     # Note the Ogham Space Mark ( ), this is a spacing character.
     s = Forth.new
-        |> Forth.eval("1\0002\0013\n4\r5 6\t7")
+        |> Forth.eval("1\x{000}2\x{001}3\n4\r5 6\t7")
         |> Forth.format_stack
     assert s == "1 2 3 4 5 6 7"
   end

--- a/largest-series-product/example.exs
+++ b/largest-series-product/example.exs
@@ -10,7 +10,7 @@ defmodule Series do
 
   def digits(number_string) do
     String.split(number_string, "", trim: true)
-    |> Enum.reduce([], fn(char, acc) -> [binary_to_integer(char)|acc] end)
+    |> Enum.reduce([], fn(char, acc) -> [String.to_integer(char)|acc] end)
     |> Enum.reverse
   end
 

--- a/minesweeper/example.exs
+++ b/minesweeper/example.exs
@@ -6,7 +6,7 @@ defmodule Minesweeper do
   def annotate([]), do: []
   def annotate(board) do
     h = length(board)
-    w = size(hd(board)) # Only 7-bit ASCII in the board, so this is safe
+    w = String.length(hd(board)) # Only 7-bit ASCII in the board, so this is safe
     annotations =
       Enum.reduce(Stream.with_index(board), %{}, fn { line, y }, acc ->
         Enum.reduce(Stream.with_index(String.to_char_list(line)), acc, fn 

--- a/mix.exs
+++ b/mix.exs
@@ -1,0 +1,18 @@
+defmodule ExercismTestRunner.Mixfile do
+  use Mix.Project
+
+  def project do
+    [app: :tests,
+     version: "0.0.1",
+     elixir: "~> 1.0",
+     deps: deps]
+  end
+
+  def application do
+    [applications: [:logger]]
+  end
+
+  defp deps do
+    [{:poison, "~> 1.4.0"}]
+  end
+end

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,1 @@
+%{"poison": {:hex, :poison, "1.4.0"}}

--- a/point-mutations/point_mutations_test.exs
+++ b/point-mutations/point_mutations_test.exs
@@ -14,19 +14,19 @@ defmodule DNATest do
   end
 
   test "no difference between identical strands" do
-    # assert DNA.hamming_distance('GGACTGA', 'GGACTGA') == 0
+    assert DNA.hamming_distance('GGACTGA', 'GGACTGA') == 0
   end
 
   test "small hamming distance in middle somewhere" do
-    # assert DNA.hamming_distance('GGACG', 'GGTCG') == 1
+    assert DNA.hamming_distance('GGACG', 'GGTCG') == 1
   end
 
   test "larger distance" do
-    # assert DNA.hamming_distance('ACCAGGG', 'ACTATGG') == 2
+    assert DNA.hamming_distance('ACCAGGG', 'ACTATGG') == 2
   end
 
   test "hamming distance is undefined for strands of different lengths" do
-    # assert DNA.hamming_distance('AAAC', 'TAGGGGAGGCTAGCGGTAGGAC') == nil
-    # assert DNA.hamming_distance('GACTACGGACAGGACACC', 'GACATCGC') == nil
+    assert DNA.hamming_distance('AAAC', 'TAGGGGAGGCTAGCGGTAGGAC') == nil
+    assert DNA.hamming_distance('GACTACGGACAGGACACC', 'GACATCGC') == nil
   end
 end

--- a/rna-transcription/rna_transcription_test.exs
+++ b/rna-transcription/rna_transcription_test.exs
@@ -14,18 +14,18 @@ defmodule DNATest do
   end
 
   test "transcribes cytosine to guanine" do
-    # assert DNA.to_rna('C') == 'G'
+    assert DNA.to_rna('C') == 'G'
   end
 
   test "transcribes thymidine to adenine" do
-    # assert DNA.to_rna('T') == 'A'
+    assert DNA.to_rna('T') == 'A'
   end
 
   test "transcribes adenine to uracil" do
-    # assert DNA.to_rna('A') == 'U'
+    assert DNA.to_rna('A') == 'U'
   end
 
   test "it transcribes all dna nucleotides to rna equivalents" do
-    # assert DNA.to_rna('ACGTGGTCTTAA') == 'UGCACCAGAAUU'
+    assert DNA.to_rna('ACGTGGTCTTAA') == 'UGCACCAGAAUU'
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,0 +1,12 @@
+
+project_root = File.cwd!
+active_problems = "config.json" |> File.read! |> Poison.decode! |> Dict.get "problems"
+
+Enum.each active_problems, fn dir ->
+    File.cd! dir
+    IO.puts "loading tests for " <> dir
+    "*test.ex*" |> Path.wildcard |> List.first |> Code.require_file
+    File.cd! project_root
+end
+
+ExUnit.start()

--- a/zipper/example.exs
+++ b/zipper/example.exs
@@ -1,4 +1,4 @@
-defrecord BinTree, value: nil, left: nil, right: nil do
+defmodule BinTree do
   @moduledoc """
   A node in a binary tree.
 
@@ -6,10 +6,11 @@ defrecord BinTree, value: nil, left: nil, right: nil do
   `left` is the left subtree (nil if no subtree).
   `right` is the right subtree (nil if no subtree).
   """
-  record_type value: any, left: BinTree.t | nil, right: BinTree.t | nil
+  @type t :: %BinTree{ value: any, left: BinTree.t | nil, right: BinTree.t | nil }
+  defstruct value: nil, left: nil, right: nil
 end
 
-defrecord BinTree.Zipper, value: nil, left: nil, right: nil, trail: [] do
+defmodule BinTree.Zipper do
   @moduledoc """
   A binary tree zipper.
 
@@ -21,10 +22,13 @@ defrecord BinTree.Zipper, value: nil, left: nil, right: nil, trail: [] do
   The trail stores the path that a zipper has taken into the tree from the root
   and the alternative branches.
   """
-  record_type value: any,
-              left: BinTree.Zipper.t | nil,
-              right: BinTree.Zipper.t | nil,
-              trail: [{ :left, any, BinTree.t } | { :right, any, BinTree.t }]
+  @type t :: %BinTree.Zipper{
+      value: any,
+      left: BinTree.Zipper.t | nil,
+      right: BinTree.Zipper.t | nil,
+      trail: [{ :left, any, BinTree.t } | { :right, any, BinTree.t }]
+    }
+  defstruct value: nil, left: nil, right: nil, trail: []
 end
 
 defmodule Zipper do
@@ -35,65 +39,65 @@ defmodule Zipper do
   Get a zipper focussed on the root node.
   """
   @spec from_tree(BT.t) :: Z.t
-  def from_tree(BT[value: v, left: l, right: r]) do
-    Z[value: v, left: l, right: r, trail: []]
+  def from_tree(%BT{ value: v, left: l, right: r}) do
+    %Z{value: v, left: l, right: r, trail: []}
   end
 
   @doc """
   Get the complete tree from a zipper.
   """
   @spec to_tree(Z.t) :: BT.t
-  def to_tree(Z[value: v, left: l, right: r, trail: t]) do
-    do_to_tree(BT[value: v, left: l, right: r], t)
+  def to_tree(%Z{value: v, left: l, right: r, trail: t}) do
+    do_to_tree(%BT{value: v, left: l, right: r}, t)
   end
 
   defp do_to_tree(b, []) do
     b
   end
   defp do_to_tree(b, [{ :left, pv, pr } | pt]) do
-    do_to_tree(BT[value: pv, left: b, right: pr], pt)
+    do_to_tree(%BT{value: pv, left: b, right: pr}, pt)
   end
   defp do_to_tree(b, [{ :right, pv, pl } | pt]) do
-    do_to_tree(BT[value: pv, left: pl, right: b], pt)
+    do_to_tree(%BT{value: pv, left: pl, right: b}, pt)
   end
 
   @doc """
   Get the value of the focus node.
   """
   @spec value(Z.t) :: any
-  def value(Z[value: v]), do: v
+  def value(%Z{ value: v }), do: v
 
   @doc """
   Get the left child of the focus node, if any.
   """
   @spec left(Z.t) :: Z.t | nil
-  def left(Z[left: nil]), do: nil
-  def left(Z[value: v, left: BT[value: lv, left: ll, right: lr], 
-             right: r, trail: zt]) do
-    Z[value: lv, left: ll, right: lr, trail: [{ :left, v, r } | zt]]
+  def left(%Z{ left: nil }), do: nil
+  def left(%Z{ value: v, left: %BT{value: lv, left: ll, right: lr},
+             right: r, trail: zt}) do
+    %Z{ value: lv, left: ll, right: lr, trail: [{ :left, v, r } | zt] }
   end
   
   @doc """
   Get the right child of the focus node, if any.
   """
   @spec right(Z.t) :: Z.t | nil
-  def right(Z[right: nil]), do: nil
-  def right(Z[value: v, left: l, 
-              right: BT[value: rv, left: rl, right: rr], trail: zt]) do
-    Z[value: rv, left: rl, right: rr, trail: [{ :right, v, l } | zt]]
+  def right(%Z{ right: nil }), do: nil
+  def right(%Z{ value: v, left: l,
+              right: %BT{value: rv, left: rl, right: rr}, trail: zt }) do
+    %Z{ value: rv, left: rl, right: rr, trail: [{ :right, v, l } | zt] }
   end
 
   @doc """
   Get the parent of the focus node, if any.
   """
   @spec up(Z.t) :: Z.t
-  def up(Z[value: v, left: l, right: r, trail: t]) do
+  def up(%Z{ value: v, left: l, right: r, trail: t }) do
     case t do
       []                        -> nil
       [{ :left, pv, pr } | zt]  ->
-        Z[value: pv, left: BT[value: v, left: l, right: r], right: pr, trail: zt]
+        %Z{ value: pv, left: %BT{value: v, left: l, right: r}, right: pr, trail: zt }
       [{ :right, pv, pl } | zt] ->
-        Z[value: pv, left: pl, right: BT[value: v, left: l, right: r], trail: zt]
+        %Z{ value: pv, left: pl, right: %BT{value: v, left: l, right: r}, trail: zt }
     end
   end
 
@@ -101,17 +105,17 @@ defmodule Zipper do
   Set the value of the focus node.
   """
   @spec set_value(Z.t, any) :: Z.t
-  def set_value(z = Z[], v), do: z.value(v)
+  def set_value(z, v), do: %{z | value: v}
   
   @doc """
   Replace the left child tree of the focus node. 
   """
   @spec set_left(Z.t, BT.t) :: Z.t
-  def set_left(z = Z[], l), do: z.left(l)
+  def set_left(z, l), do: %{z | left: l}
   
   @doc """
   Replace the right child tree of the focus node. 
   """
   @spec set_right(Z.t, BT.t) :: Z.t
-  def set_right(z = Z[], r), do: z.right(r)
+  def set_right(z, r), do: %{z | right: r}
 end

--- a/zipper/zipper.exs
+++ b/zipper/zipper.exs
@@ -1,4 +1,4 @@
-defrecord BinTree, value: nil, left: nil, right: nil do
+defmodule BinTree do
   @moduledoc """
   A node in a binary tree.
 
@@ -6,61 +6,80 @@ defrecord BinTree, value: nil, left: nil, right: nil do
   `left` is the left subtree (nil if no subtree).
   `right` is the right subtree (nil if no subtree).
   """
-  record_type value: any, left: BinTree.t | nil, right: BinTree.t | nil
+  @type t :: %BinTree{ value: any, left: BinTree.t | nil, right: BinTree.t | nil }
+  defstruct value: nil, left: nil, right: nil
 end
 
 defmodule Zipper do
   @doc """
-  Get a zipper focussed on the root node.
+  Get a zipper focused on the root node.
   """
   @spec from_tree(BT.t) :: Z.t
-  def from_tree(bt)
+  def from_tree(bt) do
+
+  end
 
   @doc """
   Get the complete tree from a zipper.
   """
   @spec to_tree(Z.t) :: BT.t
-  def to_tree(z)
+  def to_tree(z) do
+
+  end
 
   @doc """
   Get the value of the focus node.
   """
   @spec value(Z.t) :: any
-  def value(z)
+  def value(z) do
+
+  end
 
   @doc """
   Get the left child of the focus node, if any.
   """
   @spec left(Z.t) :: Z.t | nil
-  def left(z)
+  def left(z) do
+
+  end
   
   @doc """
   Get the right child of the focus node, if any.
   """
   @spec right(Z.t) :: Z.t | nil
-  def right(z)
+  def right(z) do
+
+  end
 
   @doc """
   Get the parent of the focus node, if any.
   """
   @spec up(Z.t) :: Z.t
-  def up(z)
+  def up(z) do
+
+  end
 
   @doc """
   Set the value of the focus node.
   """
   @spec set_value(Z.t, any) :: Z.t
-  def set_value(z, v)
+  def set_value(z, v) do
+
+  end
   
   @doc """
   Replace the left child tree of the focus node. 
   """
   @spec set_left(Z.t, BT.t) :: Z.t
-  def set_left(z, l)
+  def set_left(z, l) do
+
+  end
   
   @doc """
   Replace the right child tree of the focus node. 
   """
   @spec set_right(Z.t, BT.t) :: Z.t
-  def set_right(z, r)
+  def set_right(z, r) do
+
+  end
 end

--- a/zipper/zipper_test.exs
+++ b/zipper/zipper_test.exs
@@ -17,18 +17,18 @@ defmodule ZipperTest do
   defimpl Inspect, for: BT do
     import Inspect.Algebra
 
-    def inspect(BinTree[value: v, left: l, right: r], opts) do
-      concat ["(", Kernel.inspect(v, opts),
-              ":", (if l, do: Kernel.inspect(l, opts), else: ""),
-              ":", (if r, do: Kernel.inspect(r, opts), else: ""),
+    def inspect(%BinTree{value: v, left: l, right: r}, opts) do
+      concat ["(", to_doc(v, opts),
+              ":", (if l, do: to_doc(l, opts), else: ""),
+              ":", (if r, do: to_doc(r, opts), else: ""),
               ")"]
     end
   end
 
   use ExUnit.Case, async: false
   
-  defp bt(value, left, right), do: BT[value: value, left: left, right: right]
-  defp leaf(value), do: BT[value: value]
+  defp bt(value, left, right), do: %BT{value: value, left: left, right: right}
+  defp leaf(value), do: %BT{value: value}
 
   defp t1, do: bt(1, bt(2, nil,     leaf(3)), leaf(4))
   defp t2, do: bt(1, bt(5, nil,     leaf(3)), leaf(4))


### PR DESCRIPTION
This is for exercism/xelixir#12

I wrote a small utility to run all the tests with the example code and uncommented the anagram tests since the `@tag pending` method of skipping tests is now possible. Unfortunately ExUnit doesn't seem to be reporting skipped tests yet for some reason, just the fact that a tag is being excluded so I'll throw those in there once skipped tests start being reported (which will deal with exercism/xelixir#47). ~~I'm opening a PR on elixir-lang/elixir to get the CLI output implemented, the data is already in place it's just not being output~~ It seems like the v1.0 branch diverged from master a long time ago and the "#{x} skipped" output is stuck in a commit from November 2014, still checking into elixir-lang/elixir#2898.

Let me know if there's anything I missed or can improve.

(I presume I should squash the commits? Never really done a PR with more than a single commit before.)