### PR TITLE
update allergies example to be consistent with problem

### DIFF
--- a/allergies/allergies.exs
+++ b/allergies/allergies.exs
@@ -1,9 +1,6 @@
 defmodule Allergies do
   @doc """
   List the allergies for which the corresponding flag bit is true.
-
-  Allergies should be ordered, starting with the allergie with the least
-  significant bit ("eggs").
   """
   @spec list(non_neg_integer) :: [String.t]
   def list(flags) do

--- a/allergies/allergies_test.exs
+++ b/allergies/allergies_test.exs
@@ -60,7 +60,8 @@ defmodule AllergiesTest do
     Allergies.list(509) |> assert_is_a_set_containing ["eggs", "shellfish", "strawberries", "tomatoes", "chocolate", "pollen", "cats"]
   end
 
-  defp assert_is_a_set_containing(set, to_contain) do
+  defp assert_is_a_set_containing(list, to_contain) do
+    set = Enum.into(list, HashSet.new)
     same_contents = to_contain
       |> Enum.into(HashSet.new)
       |> Set.equal?(set)

--- a/allergies/example.exs
+++ b/allergies/example.exs
@@ -14,8 +14,7 @@ defmodule Allergies do
 
   def list(flags) do
     Enum.with_index(@allergens)
-      |> Enum.filter_map(&(flagged? flags, &1), fn({item, _}) -> item end)
-      |> Enum.into(HashSet.new)
+    |> Enum.filter_map(&(flagged? flags, &1), fn({item, _}) -> item end)
   end
 
   def allergic_to?(flags, item) do


### PR DESCRIPTION
I was going through the allergies exercise earlier today and the tests broke with the following exception:
```
  1) test allergic_to_more_than_eggs_but_not_peanuts (AllergiesTest)
     allergies_test.exs:33
     ** (ArgumentError) unsupported set: ["eggs", "shellfish"]
     stacktrace:
       (elixir) lib/set.ex:334: Set.unsupported_set/1
       (elixir) lib/set.ex:163: Set.equal?/2
       allergies_test.exs:66: AllergiesTest.assert_is_a_set_containing/2
       allergies_test.exs:34
```
I looked into it and noticed that this was being caused by the assertion helper here https://github.com/exercism/xelixir/blob/f73d5fa4552f6265fe30ee1e1916aa4338de15ff/allergies/allergies_test.exs#L63, which passes the list returned by `Allergies.list/1` to `Set.equal?/2` and to `Set.to_list/1`. 

I dug in more and found #52, which seemed to introduce this behavior. It looks like it was originally written because of this comment https://github.com/exercism/xelixir/pull/52#issue-93215815, which is confusing because the spec in `allergies.exs` did actually specify the order:
> Allergies should be ordered, starting with the allergie with the least
  significant bit ("eggs").

So, I did the following:
 1. Remove the order specification from `allergies.exs` to keep it consistent with how the test assertions are being done in order agnostic fashion
 1. Update the assertion helper to take a plain list instead of a `HashSet`, since that's what the spec asks for.
 1. Updated the example code to be consistent with the spec by returning a `[String.t]`.

I hope this is helpful! I'm happy to make adjustments or update if I misunderstood anything.

And finally, thanks for building this :)