### PR TITLE
Add a test: correct # of digits but wrong format

### DIFF
--- a/phone-number/example.exs
+++ b/phone-number/example.exs
@@ -13,17 +13,14 @@ defmodule Phone do
   @spec number(String.t) :: String.t
   def number(raw) do
     raw
-    |> numeric
-    |> String.graphemes
-    |> do_number
+    |> to_parts
     |> to_string
   end
 
-  defp numeric(input), do: String.replace(input, ~r/[^0-9]*/, "")
-
-  defp do_number(input) when length(input) == 10, do: input
-  defp do_number(["1"|input]) when length(input) == 10, do: input
-  defp do_number(_), do: @bad_result
+  @spec to_parts(String.t) :: [String.t]
+  defp to_parts(raw) do
+    Regex.run(~r/^\D*?1?\D*?(\d{3})\D*(\d{3})\D*(\d{4})$/, raw, [capture: :all_but_first]) || ["000", "000", "0000"]
+  end
 
   @doc """
   Get the area code of a phone number.
@@ -32,7 +29,23 @@ defmodule Phone do
   """
   @spec area_code(String.t) :: String.t
   def area_code(str) do
-    number(str) |> String.slice(0, 3)
+    str
+    |> to_parts
+    |> List.first
+  end
+
+  @spec prefix(String.t) :: String.t
+  def prefix(str) do
+    str
+    |> to_parts
+    |> Enum.at(1)
+  end
+
+  @spec line(String.t) :: String.t
+  def line(str) do
+    str
+    |> to_parts
+    |> List.last
   end
 
   @doc """
@@ -40,7 +53,6 @@ defmodule Phone do
   """
   @spec pretty(String.t) :: String.t
   def pretty(str) do
-    c = number(str)
-    "(#{String.slice(c, 0, 3)}) #{String.slice(c, 3, 3)}-#{String.slice(c,6,4)}"
+    "(#{area_code(str)}) #{prefix(str)}-#{line(str)}"
   end
 end

--- a/phone-number/phone_number_test.exs
+++ b/phone-number/phone_number_test.exs
@@ -33,6 +33,11 @@ defmodule PhoneTest do
   test "invalid when 9 digits" do
     assert Phone.number("123456789") == "0000000000"
   end
+
+  @tag :pending
+  test "invalid when proper number of digits but letters mixed in" do
+    assert Phone.number("1a2a3a4a5a6a7a8a9a0a") == "0000000000"
+  end
   
   @tag :pending
   test "area code" do


### PR DESCRIPTION
I copied over a test that I think is important from the Ruby version. It
checks that the number of digits might be correct while the formatting
of the phone number string might be wrong.

I think that the key to this exercise is to check for the 3-3-4 format,
where the separators can be anything, but there needs to be a group of 3
digits followed by another group of 3 digits followed by another group
of 4 digits, optionally prefixed with a single "1".

When I added this test to my initial iteration, the suite failed. Most
of the other submissions I saw would, I believe, also fail. So I think
this test is important for clarifying the problem space.