### PR TITLE
Change test order for a better flow

### DIFF
--- a/word-count/word_count_test.exs
+++ b/word-count/word_count_test.exs
@@ -51,14 +51,14 @@ defmodule WordsTest do
   end
 
   @tag :pending
-  test "German" do
-    expected = %{"götterfunken" => 1, "schöner" => 1, "freude" => 1}
-    assert Words.count("Freude schöner Götterfunken") == expected
-  end
-
-  @tag :pending
   test "normalize case" do
     expected = %{"go" => 3}
     assert Words.count("go Go GO") == expected
+  end
+
+  @tag :pending
+  test "German" do
+    expected = %{"götterfunken" => 1, "schöner" => 1, "freude" => 1}
+    assert Words.count("Freude schöner Götterfunken") == expected
   end
 end


### PR DESCRIPTION
While doing the word count exercise I noticed that the test `normalize case` comes only after the `German` one, but the `German` test also requires a case normalization.

So in this pull request I've changed the order of those two tests to make sure that when we get to the `German` test we already have covered the case normalization.