### PR TITLE
added @tag :pending to all test files' tests except the first test of…

### DIFF
--- a/allergies/allergies_test.exs
+++ b/allergies/allergies_test.exs
@@ -6,56 +6,69 @@ end
 
 
 ExUnit.start
+ExUnit.configure exclude: :pending
 
 defmodule AllergiesTest do
   use ExUnit.Case, async: true
 
+  # @tag :pending
   test "no_allergies_at_all" do
     Allergies.list(0) |> assert_is_a_set_containing []
   end
 
+  @tag :pending
   test "allergic_to_just_eggs" do
     Allergies.list(1) |> assert_is_a_set_containing ["eggs"]
   end
 
+  @tag :pending
   test "allergic_to_just_peanuts" do
     Allergies.list(2) |> assert_is_a_set_containing ["peanuts"]
   end
 
+  @tag :pending
   test "allergic_to_just_strawberries" do
     Allergies.list(8) |> assert_is_a_set_containing ["strawberries"]
   end
 
+  @tag :pending
   test "allergic_to_eggs_and_peanuts" do
     Allergies.list(3) |> assert_is_a_set_containing ["eggs", "peanuts"]
   end
 
+  @tag :pending
   test "allergic_to_more_than_eggs_but_not_peanuts" do
     Allergies.list(5) |> assert_is_a_set_containing ["eggs", "shellfish"]
   end
 
+  @tag :pending
   test "allergic_to_lots_of_stuff" do
     Allergies.list(248) |> assert_is_a_set_containing ["strawberries", "tomatoes", "chocolate", "pollen", "cats"]
   end
 
+  @tag :pending
   test "allergic_to_everything" do
     Allergies.list(255) |> assert_is_a_set_containing ["eggs", "peanuts", "shellfish", "strawberries", "tomatoes", "chocolate", "pollen", "cats"]
   end
 
+  @tag :pending
   test "no_allergies_means_not_allergic" do
     assert ! Allergies.allergic_to?(0, "peanuts")
     assert ! Allergies.allergic_to?(0, "cats")
     assert ! Allergies.allergic_to?(0, "strawberries")
   end
 
+  @tag :pending
   test "is_allergic_to_eggs" do
     assert Allergies.allergic_to?(1, "eggs")
   end
 
+  @tag :pending
   test "allergic_to_eggs_in_addition_to_other_stuff" do
     assert Allergies.allergic_to?(5, "eggs")
   end
 
+  @tag :pending
   test "ignore_non_allergen_score_parts" do
     Allergies.list(509) |> assert_is_a_set_containing ["eggs", "shellfish", "strawberries", "tomatoes", "chocolate", "pollen", "cats"]
   end

--- a/anagram/anagram_test.exs
+++ b/anagram/anagram_test.exs
@@ -5,60 +5,72 @@ else
 end
 
 ExUnit.start
+ExUnit.configure exclude: :pending
 
 defmodule AnagramTest do
   use ExUnit.Case
 
+  # @tag :pending
   test "no matches" do
     matches = Anagram.match "diaper", ["hello", "world", "zombies", "pants"]
     assert matches == []
   end
 
+  @tag :pending
   test "detect simple anagram" do
     matches = Anagram.match "ant", ["tan", "stand", "at"]
     assert matches == ["tan"]
   end
 
+  @tag :pending
   test "detect multiple anagrams" do
     matches = Anagram.match "master", ["stream", "pigeon", "maters"]
     assert matches == ["stream", "maters"]
   end
 
+  @tag :pending
   test "do not detect anagram subsets" do
     matches = Anagram.match "good", ~w(dog goody)
     assert matches == []
   end
 
+  @tag :pending
   test "detect anagram" do
     matches = Anagram.match "listen", ~w(enlists google inlets banana)
     assert matches == ["inlets"]
   end
 
+  @tag :pending
   test "multiple anagrams" do
     matches = Anagram.match "allergy", ~w(gallery ballerina regally clergy largely leading)
     assert matches == ["gallery", "regally", "largely"]
   end
 
+  @tag :pending
   test "anagrams must use all letters exactly once" do
     matches = Anagram.match "patter", ["tapper"]
     assert matches == []
   end
 
+  @tag :pending
   test "detect anagrams with case-insensitive subject" do
     matches = Anagram.match "Orchestra", ~w(cashregister carthorse radishes)
     assert matches == ["carthorse"]
   end
 
+  @tag :pending
   test "detect anagrams with case-insensitive candidate" do
     matches = Anagram.match "orchestra", ~w(cashregister Carthorse radishes)
     assert matches == ["Carthorse"]
   end
 
+  @tag :pending
   test "anagrams must not be the source word" do
     matches = Anagram.match "corn", ["corn", "dark", "Corn", "rank", "CORN", "cron", "park"]
     assert matches == ["cron"]
   end
 
+  @tag :pending
   test "do not detect words based on checksum" do
     matches = Anagram.match "mass", ["last"]
     assert matches == []

--- a/atbash-cipher/atbash_cipher_test.exs
+++ b/atbash-cipher/atbash_cipher_test.exs
@@ -5,38 +5,47 @@ else
 end
 
 ExUnit.start
+ExUnit.configure exclude: :pending
 
 defmodule AtbashTest do
   use ExUnit.Case, async: true
 
+  # @tag :pending
   test "encode no" do
     assert Atbash.encode("no") == "ml"
   end
 
+  @tag :pending
   test "encode yes" do
     assert Atbash.encode("yes") == "bvh"
   end
 
+  @tag :pending
   test "encode OMG" do
     assert Atbash.encode("OMG") == "lnt"
   end
 
+  @tag :pending
   test "encode O M G" do
     assert Atbash.encode("O M G") == "lnt"
   end
 
+  @tag :pending
   test "encode long word" do
     assert Atbash.encode("mindblowingly") == "nrmwy oldrm tob"
   end
 
+  @tag :pending
   test "encode numbers" do
     assert Atbash.encode("Testing, 1 2 3, testing.") == "gvhgr mt123 gvhgr mt"
   end
 
+  @tag :pending
   test "encode sentence" do
     assert Atbash.encode("Truth is fiction.") == "gifgs rhurx grlm"
   end
 
+  @tag :pending
   test "encode all the things" do
     plaintext = "The quick brown fox jumps over the lazy dog."
     cipher = "gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt"

--- a/bank-account/bank_account_test.exs
+++ b/bank-account/bank_account_test.exs
@@ -5,6 +5,7 @@ else
 end
 
 ExUnit.start
+ExUnit.configure exclude: :pending
 
 # The BankAccount module should support four calls:
 #
@@ -31,16 +32,19 @@ defmodule BankAccountTest do
     { :ok, [ account: account ] }
   end
 
+  # @tag :pending
   test "initial balance is 0", context do
     assert BankAccount.balance(context[:account]) == 0
   end
 
+  @tag :pending
   test "incrementing and checking balance", context do
     assert BankAccount.balance(context[:account]) == 0
     BankAccount.update(context[:account], 10)
     assert BankAccount.balance(context[:account]) == 10
   end
 
+  @tag :pending
   test "incrementing balance from another process then checking it from test process", context do
     assert BankAccount.balance(context[:account]) == 0
     this = self()
@@ -50,8 +54,8 @@ defmodule BankAccountTest do
     end)
     receive do
       :continue -> :ok
-    after 
-      1000 -> flunk("Timeout") 
+    after
+      1000 -> flunk("Timeout")
     end
     assert BankAccount.balance(context[:account]) == 20
   end

--- a/binary/binary_test.exs
+++ b/binary/binary_test.exs
@@ -5,38 +5,47 @@ else
 end
 
 ExUnit.start
+ExUnit.configure exclude: :pending
 
 defmodule BinaryTest do
   use ExUnit.Case, async: true
 
+  # @tag :pending
   test "binary 1 is decimal 1" do
     assert Binary.to_decimal("1") == 1
   end
 
+  @tag :pending
   test "binary 10 is decimal 2" do
     assert Binary.to_decimal("10") == 2
   end
 
+  @tag :pending
   test "binary 11 is decimal 3" do
     assert Binary.to_decimal("11") == 3
   end
 
+  @tag :pending
   test "binary 100 is decimal 4" do
     assert Binary.to_decimal("100") == 4
   end
 
+  @tag :pending
   test "binary 1001 is decimal 9" do
     assert Binary.to_decimal("1001") == 9
   end
 
+  @tag :pending
   test "binary 11010 is decimal 26" do
     assert Binary.to_decimal("11010") == 26
   end
 
+  @tag :pending
   test "binary 10001101000 is decimal 1128" do
     assert Binary.to_decimal("10001101000") == 1128
   end
 
+  @tag :pending
   test "invalid binary is decimal 0" do
     assert Binary.to_decimal("carrot") == 0
   end

--- a/custom-set/custom-set_test.exs
+++ b/custom-set/custom-set_test.exs
@@ -5,6 +5,7 @@ else
 end
 
 ExUnit.start
+ExUnit.configure exclude: :pending
 
 defmodule CustomSetTest do
   use ExUnit.Case
@@ -13,12 +14,14 @@ defmodule CustomSetTest do
   # is a tuple with as first element `CustomSet`. A record with tag `CustomSet`
   # will meet this requirement.
 
+  # @tag :pending
   test "delete" do
     assert Set.equal?(Set.delete(CustomSet.new([3,2,1]), 2), CustomSet.new([1,3]))
     assert Set.equal?(Set.delete(CustomSet.new([3,2,1]), 4), CustomSet.new([1,2,3]))
     assert Set.equal?(Set.delete(CustomSet.new([3,2,1]), 2.0), CustomSet.new([1,2,3]))
   end
 
+  @tag :pending
   test "difference" do
     assert Set.equal?(
       Set.difference(CustomSet.new([1,2,3]), CustomSet.new([2,4])),
@@ -28,6 +31,7 @@ defmodule CustomSetTest do
       CustomSet.new([1,2.0,3]))
   end
 
+  @tag :pending
   test "disjoint?" do
     assert Set.disjoint?(CustomSet.new([1,2]), CustomSet.new([3,4]))
     refute Set.disjoint?(CustomSet.new([1,2]), CustomSet.new([2,3]))
@@ -35,11 +39,13 @@ defmodule CustomSetTest do
     assert Set.disjoint?(CustomSet.new, CustomSet.new)
   end
 
+  @tag :pending
   test "empty" do
     assert Set.equal?(Set.empty(CustomSet.new([1,2])), CustomSet.new)
     assert Set.equal?(Set.empty(CustomSet.new), CustomSet.new)
   end
 
+  @tag :pending
   test "intersection" do
     assert Set.equal?(
       Set.intersection(CustomSet.new([:a, :b, :c]), CustomSet.new([:a, :c, :d])),
@@ -49,6 +55,7 @@ defmodule CustomSetTest do
       CustomSet.new([3]))
   end
 
+  @tag :pending
   test "member?" do
     assert Set.member?(CustomSet.new([1,2,3]), 2)
     assert Set.member?(CustomSet.new(1..3), 2)
@@ -56,6 +63,7 @@ defmodule CustomSetTest do
     refute Set.member?(CustomSet.new(1..3), 4)
   end
 
+  @tag :pending
   test "put" do
     assert Set.equal?(
       Set.put(CustomSet.new([1,2,4]), 3),
@@ -68,12 +76,14 @@ defmodule CustomSetTest do
       CustomSet.new([1,2,3,3.0]))
   end
 
+  @tag :pending
   test "size" do
     assert Set.size(CustomSet.new) == 0
     assert Set.size(CustomSet.new([1,2,3])) == 3
     assert Set.size(CustomSet.new([1,2,3,2])) == 3
   end
 
+  @tag :pending
   test "subset?" do
     assert Set.subset?(CustomSet.new([1,2,3]), CustomSet.new([1,2,3]))
     assert Set.subset?(CustomSet.new([1,2,3]), CustomSet.new([4,1,2,3]))
@@ -83,12 +93,14 @@ defmodule CustomSetTest do
     assert Set.subset?(CustomSet.new, CustomSet.new)
   end
 
+  @tag :pending
   test "to_list" do
     assert Enum.sort(Set.to_list(CustomSet.new)) == []
     assert Enum.sort(Set.to_list(CustomSet.new([3,1,2]))) == [1,2,3]
     assert Enum.sort(Set.to_list(CustomSet.new([3,1,2,1]))) == [1,2,3]
   end
 
+  @tag :pending
   test "union" do
     assert Set.equal?(
       CustomSet.union(CustomSet.new([1,3]), CustomSet.new([2])),
@@ -107,6 +119,7 @@ defmodule CustomSetTest do
       CustomSet.new([]))
   end
 
+  @tag :pending
   test "inspect" do
     assert inspect(CustomSet.new) == "#<CustomSet []>"
     assert inspect(CustomSet.new([1,3,2])) == "#<CustomSet [1, 2, 3]>"

--- a/difference-of-squares/difference_of_squares_test.exs
+++ b/difference-of-squares/difference_of_squares_test.exs
@@ -5,42 +5,52 @@ else
 end
 
 ExUnit.start
+ExUnit.configure exclude: :pending
 
 defmodule DifferenceOfSquaresTest do
   use ExUnit.Case, async: true
 
+  # @tag :pending
   test "square of sums to 5" do
     assert Squares.square_of_sums(5) == 225
   end
 
+  @tag :pending
   test "sum of squares to 5" do
     assert Squares.sum_of_squares(5) == 55
   end
 
+  @tag :pending
   test "difference of sums to 5" do
     assert Squares.difference(5) == 170
   end
 
+  @tag :pending
   test "square of sums to 10" do
     assert Squares.square_of_sums(10) == 3025
   end
 
+  @tag :pending
   test "sum of squares to 10" do
     assert Squares.sum_of_squares(10) == 385
   end
 
+  @tag :pending
   test "difference of sums to 10" do
     assert Squares.difference(10) == 2640
   end
 
+  @tag :pending
   test "square of sums to 100" do
     assert Squares.square_of_sums(100) == 25502500
   end
 
+  @tag :pending
   test "sum of squares to 100" do
     assert Squares.sum_of_squares(100) == 338350
   end
 
+  @tag :pending
   test "difference of sums to 100" do
     assert Squares.difference(100) == 25164150
   end

--- a/dot-dsl/dot-dsl_test.exs
+++ b/dot-dsl/dot-dsl_test.exs
@@ -5,6 +5,7 @@ else
 end
 
 ExUnit.start
+ExUnit.configure exclude: :pending
 
 defmodule DotTest do
   use ExUnit.Case, async: true
@@ -21,26 +22,32 @@ defmodule DotTest do
     end
   end
 
+  # @tag :pending
   test "empty graph" do
     assert %Graph{} == exprt(Dot.graph do end)
   end
-  
+
+  @tag :pending
   test "graph with one node" do
     assert %Graph{nodes: [{:a, []}]} == exprt(Dot.graph do a end)
   end
-  
+
+  @tag :pending
   test "graph with one node with keywords" do
     assert %Graph{nodes: [{:a, [color: :green]}]} == exprt(Dot.graph do a [color: :green] end)
   end
 
+  @tag :pending
   test "graph with one edge" do
     assert %Graph{edges: [{:a, :b, []}]} == exprt(Dot.graph do a -- b end)
   end
 
+  @tag :pending
   test "graph with just attribute" do
     assert %Graph{attrs: [foo: 1]} == exprt(Dot.graph do graph [foo: 1] end)
   end
-  
+
+  @tag :pending
   test "graph with attributes" do
     assert %Graph{
       attrs: [bar: true, foo: 1, title: "Testing Attrs"],
@@ -61,7 +68,8 @@ defmodule DotTest do
       graph [bar: true]
     end)
   end
-  
+
+  @tag :pending
   test "keywords stuck to graph without space" do
     assert_raise ArgumentError, fn ->
       exprt(Dot.graph do
@@ -70,6 +78,7 @@ defmodule DotTest do
     end
   end
 
+  @tag :pending
   test "keywords stuck to node without space" do
     assert_raise ArgumentError, fn ->
       exprt(Dot.graph do
@@ -77,7 +86,8 @@ defmodule DotTest do
       end)
     end
   end
-  
+
+  @tag :pending
   test "keywords stuck to edge without space" do
     assert_raise ArgumentError, fn ->
       exprt(Dot.graph do
@@ -86,6 +96,7 @@ defmodule DotTest do
     end
   end
 
+  @tag :pending
   test "invalid statement: int" do
     assert_raise ArgumentError, fn ->
       exprt(Dot.graph do
@@ -94,7 +105,8 @@ defmodule DotTest do
       end)
     end
   end
-  
+
+  @tag :pending
   test "invalid statement: list" do
     assert_raise ArgumentError, fn ->
       exprt(Dot.graph do
@@ -102,7 +114,8 @@ defmodule DotTest do
       end)
     end
   end
-  
+
+  @tag :pending
   test "invalid statement: qualified atom" do
     assert_raise ArgumentError, fn ->
       exprt(Dot.graph do
@@ -110,7 +123,8 @@ defmodule DotTest do
       end)
     end
   end
-  
+
+  @tag :pending
   test "invalid statement: graph with no keywords" do
     assert_raise ArgumentError, fn ->
       exprt(Dot.graph do
@@ -118,7 +132,8 @@ defmodule DotTest do
       end)
     end
   end
-  
+
+  @tag :pending
   test "two attribute lists" do
     assert_raise ArgumentError, fn ->
       exprt(Dot.graph do
@@ -126,7 +141,8 @@ defmodule DotTest do
       end) |> IO.inspect
     end
   end
-  
+
+  @tag :pending
   test "non-keyword attribute list" do
     assert_raise ArgumentError, fn ->
       exprt(Dot.graph do
@@ -135,15 +151,16 @@ defmodule DotTest do
     end
   end
 
+  @tag :pending
   test "int edge" do
     assert_raise ArgumentError, fn ->
       exprt(Dot.graph do
-        1 -- b 
+        1 -- b
       end)
     end
     assert_raise ArgumentError, fn ->
       exprt(Dot.graph do
-        a -- 2 
+        a -- 2
       end)
     end
   end

--- a/etl/etl_test.exs
+++ b/etl/etl_test.exs
@@ -5,10 +5,12 @@ else
 end
 
 ExUnit.start
+ExUnit.configure exclude: :pending
 
 defmodule TransformTest do
   use ExUnit.Case, async: true
 
+  # @tag :pending
   test "transform one value" do
     old = %{1 => ["WORLD"]}
     expected = %{"world" => 1}
@@ -16,6 +18,7 @@ defmodule TransformTest do
     assert ETL.transform(old) == expected
   end
 
+  @tag :pending
   test "transform more values" do
     old = %{1 => ["WORLD", "GSCHOOLERS"]}
     expected = %{"world" => 1, "gschoolers" => 1}
@@ -23,6 +26,7 @@ defmodule TransformTest do
     assert ETL.transform(old) == expected
   end
 
+  @tag :pending
   test "more keys" do
     old = %{1 => ["APPLE", "ARTICHOKE"], 2 => ["BOAT", "BALLERINA"]}
     expected = %{
@@ -35,6 +39,7 @@ defmodule TransformTest do
     assert ETL.transform(old) == expected
   end
 
+  @tag :pending
   test "full dataset" do
     old = %{
       1 =>  ~W(A E I O U L N R S T),

--- a/forth/forth_test.exs
+++ b/forth/forth_test.exs
@@ -5,15 +5,18 @@ else
 end
 
 ExUnit.start
+ExUnit.configure exclude: :pending
 
 defmodule ForthTest do
   use ExUnit.Case
 
+  # @tag :pending
   test "no input, no stack" do
     s = Forth.new |> Forth.format_stack
     assert s == ""
   end
 
+  @tag :pending
   test "numbers just get pushed onto the stack" do
     s = Forth.new
         |> Forth.eval("1 2 3 4 5")
@@ -21,6 +24,7 @@ defmodule ForthTest do
     assert s == "1 2 3 4 5"
   end
 
+  @tag :pending
   test "non-word characters are separators" do
     # Note the Ogham Space Mark ( ), this is a spacing character.
     s = Forth.new
@@ -29,6 +33,7 @@ defmodule ForthTest do
     assert s == "1 2 3 4 5 6 7"
   end
 
+  @tag :pending
   test "basic arithmetic" do
     s = Forth.new
         |> Forth.eval("1 2 + 4 -")
@@ -40,12 +45,14 @@ defmodule ForthTest do
     assert s == "2"
   end
 
+  @tag :pending
   test "division by zero" do
     assert_raise Forth.DivisionByZero, fn ->
       Forth.new |> Forth.eval("4 2 2 - /")
     end
   end
 
+  @tag :pending
   test "dup" do
     s = Forth.new
         |> Forth.eval("1 DUP")
@@ -59,7 +66,8 @@ defmodule ForthTest do
       Forth.new |> Forth.eval("dup")
     end
   end
-  
+
+  @tag :pending
   test "drop" do
     s = Forth.new
         |> Forth.eval("1 drop")
@@ -74,6 +82,7 @@ defmodule ForthTest do
     end
   end
 
+  @tag :pending
   test "swap" do
     s = Forth.new
         |> Forth.eval("1 2 swap")
@@ -90,7 +99,8 @@ defmodule ForthTest do
       Forth.new |> Forth.eval("swap")
     end
   end
-  
+
+  @tag :pending
   test "over" do
     s = Forth.new
         |> Forth.eval("1 2 over")
@@ -108,6 +118,7 @@ defmodule ForthTest do
     end
   end
 
+  @tag :pending
   test "defining a new word" do
     s = Forth.new
         |> Forth.eval(": dup-twice dup dup ;")
@@ -116,6 +127,7 @@ defmodule ForthTest do
     assert s == "1 1 1"
   end
 
+  @tag :pending
   test "redefining an existing word" do
     s = Forth.new
         |> Forth.eval(": foo dup ;")
@@ -124,7 +136,8 @@ defmodule ForthTest do
         |> Forth.format_stack
     assert s == "1 1 1"
   end
-  
+
+  @tag :pending
   test "redefining an existing built-in word" do
     s = Forth.new
         |> Forth.eval(": swap dup ;")
@@ -133,19 +146,22 @@ defmodule ForthTest do
     assert s == "1 1"
   end
 
+  @tag :pending
   test "defining words with odd characters" do
     s = Forth.new
         |> Forth.eval(": € 220371 ; €")
         |> Forth.format_stack
     assert s == "220371"
   end
-  
+
+  @tag :pending
   test "defining a number" do
     assert_raise Forth.InvalidWord, fn ->
       Forth.new |> Forth.eval(": 1 2 ;")
     end
   end
 
+  @tag :pending
   test "calling a non-existing word" do
     assert_raise Forth.UnknownWord, fn ->
       Forth.new |> Forth.eval("1 foo")

--- a/gigasecond/gigasecond_test.exs
+++ b/gigasecond/gigasecond_test.exs
@@ -5,26 +5,31 @@ else
 end
 
 ExUnit.start
+ExUnit.configure exclude: :pending
 
 defmodule GigasecondTest do
   use ExUnit.Case
 
+  # @tag :pending
   test "from 4/25/2011" do
     assert Gigasecond.from({2011, 4, 25}) == {2043, 1, 1}
   end
 
+  @tag :pending
   test "from 6/13/1977" do
-    # assert Gigasecond.from({1977, 6, 13}) == {2009, 2, 19}
+    assert Gigasecond.from({1977, 6, 13}) == {2009, 2, 19}
   end
 
+  @tag :pending
   test "from 7/19/1959" do
-    # assert Gigasecond.from({1959, 7, 19}) == {1991, 3, 27}
+    assert Gigasecond.from({1959, 7, 19}) == {1991, 3, 27}
   end
 
+  @tag :pending
   test "yourself" do
     # customize these values for yourself
-    #your_birthday = {year1, month1, day1}
-    #assert Gigasecond.from(your_birthday) == {year2, month2, day2}
+    # your_birthday = {year1, month1, day1}
+    # assert Gigasecond.from(your_birthday) == {year2, month2, day2}
   end
 end
 

--- a/grade-school/grade_school_test.exs
+++ b/grade-school/grade_school_test.exs
@@ -11,31 +11,31 @@ defmodule SchoolTest do
   use ExUnit.Case, async: true
 
   def db, do: %{}
-  
+
   test "add student" do
     actual = School.add(db, "Aimee", 2)
     assert actual == %{2 => ["Aimee"]}
   end
-  
+
   @tag :pending
   test "add more students in same class" do
     actual = db
      |> School.add("James", 2)
      |> School.add("Blair", 2)
      |> School.add("Paul", 2)
-    
+
     assert Enum.sort(actual[2]) == ["Blair", "James", "Paul"]
   end
-  
+
   @tag :pending
   test "add students to different grades" do
     actual = db
      |> School.add("Chelsea", 3)
      |> School.add("Logan", 7)
-    
+
     assert actual == %{3 => ["Chelsea"], 7 => ["Logan"]}
   end
-  
+
   @tag :pending
   test "get students in a grade" do
     actual = db
@@ -43,15 +43,15 @@ defmodule SchoolTest do
      |> School.add("Franklin", 5)
      |> School.add("Jeff", 1)
      |> School.grade(5)
-    
+
     assert Enum.sort(actual) == ["Bradley", "Franklin"]
   end
-  
+
   @tag :pending
   test "get students in a non existant grade" do
     assert [] == School.grade(db, 1)
   end
-  
+
   @tag :pending
   test "sort school by grade and by student name" do
     actual = db
@@ -61,13 +61,13 @@ defmodule SchoolTest do
      |> School.add("Kareem", 6)
      |> School.add("Kyle", 3)
      |> School.sort
-    
+
     expected = %{
      3 => ["Kyle"],
      4 => ["Bart", "Christopher", "Jennifer"],
      6 => ["Kareem"]
     }
-     
+
     assert expected == actual
   end
 

--- a/grains/grains_test.exs
+++ b/grains/grains_test.exs
@@ -5,6 +5,7 @@ else
 end
 
 ExUnit.start
+ExUnit.configure exclude: :pending
 
 # NOTE: :math.pow/2 doesn't do what you'd expect:
 # `:math.pow(2, 64) == :math.pow(2, 64) - 1` is true.
@@ -15,34 +16,42 @@ ExUnit.start
 defmodule GrainsTest do
   use ExUnit.Case
 
+  # @tag :pending
   test "square 1" do
     assert Grains.square(1) === 1
   end
 
+  @tag :pending
   test "square 2" do
     assert Grains.square(2) === 2
   end
 
+  @tag :pending
   test "square 3" do
     assert Grains.square(3) === 4
   end
 
+  @tag :pending
   test "square 4" do
     assert Grains.square(4) === 8
   end
 
+  @tag :pending
   test "square 16" do
     assert Grains.square(16) === 32768
   end
 
+  @tag :pending
   test "square 32" do
     assert Grains.square(32) === 2147483648
   end
 
+  @tag :pending
   test "square 64" do
     assert Grains.square(64) === 9223372036854775808
   end
 
+  @tag :pending
   test "total grains" do
     assert Grains.total === 18446744073709551615
   end

--- a/largest-series-product/largest_series_product_test.exs
+++ b/largest-series-product/largest_series_product_test.exs
@@ -5,82 +5,102 @@ else
 end
 
 ExUnit.start
+ExUnit.configure exclude: :pending
 
 defmodule LargestSeriesProductTest do
   use ExUnit.Case, async: false
 
+  # @tag :pending
   test "digits" do
     assert Series.digits("0123456789") == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
   end
 
+  @tag :pending
   test "same digits reversed" do
     assert Series.digits("9876543210") == [9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
   end
 
+  @tag :pending
   test "fewer digits" do
     assert Series.digits("87654") == [8, 7, 6, 5, 4]
   end
 
+  @tag :pending
   test "some other digits" do
     assert Series.digits("936923468") == [9, 3, 6, 9, 2, 3, 4, 6, 8]
   end
 
+  @tag :pending
   test "slices of zero" do
     assert Series.digits("") == []
   end
 
+  @tag :pending
   test "slices of two" do
     assert Series.slices("01234", 2) == [[0, 1], [1, 2], [2, 3], [3, 4]]
   end
 
+  @tag :pending
   test "other slices of two" do
     assert Series.slices("98273463", 2) == [[9, 8], [8, 2], [2, 7], [7, 3], [3, 4], [4, 6], [6, 3]]
   end
 
+  @tag :pending
   test "slices of three" do
     assert Series.slices("01234", 3) == [[0, 1, 2], [1, 2, 3], [2, 3, 4]]
   end
 
+  @tag :pending
   test "other slices of three" do
     assert Series.slices("982347", 3) == [[9, 8, 2], [8, 2, 3], [2, 3, 4], [3, 4, 7]]
   end
 
+  @tag :pending
   test "largest product of 2" do
     assert Series.largest_product("0123456789", 2) == 72
   end
 
+  @tag :pending
   test "largest product of a tiny number" do
     assert Series.largest_product("12", 2) == 2
   end
 
+  @tag :pending
   test "another tiny number" do
     assert Series.largest_product("19", 2) == 9
   end
 
+  @tag :pending
   test "largest product of 2 shuffled" do
     assert Series.largest_product("576802143", 2) == 48
   end
 
+  @tag :pending
   test "largest product of 3" do
     assert Series.largest_product("0123456789", 3) == 504
   end
 
+  @tag :pending
   test "largest product of 3 shuffled" do
     assert Series.largest_product("1027839564", 3) == 270
   end
 
+  @tag :pending
   test "largest product of 5" do
     assert Series.largest_product("0123456789", 5) == 15120
   end
 
+  @tag :pending
   test "some big number" do
     assert Series.largest_product("73167176531330624919225119674426574742355349194934", 6) == 23520
   end
 
+  @tag :pending
   test "some other big number" do
     assert Series.largest_product("52677741234314237566414902593461595376319419139427", 6) == 28350
   end
 
+  @tag :pending
   test "identity" do
     assert Series.largest_product("", 0) == 1
   end

--- a/leap/leap_test.exs
+++ b/leap/leap_test.exs
@@ -5,23 +5,28 @@ else
 end
 
 ExUnit.start
+ExUnit.configure exclude: :pending
 
 defmodule LeapTest do
   use ExUnit.Case, async: true
 
+  # @tag :pending
   test "vanilla leap year" do
     assert Year.leap_year?(1996)
   end
 
+  @tag :pending
   test "any old year" do
-    # assert ! Year.leap_year?(1997)
+    refute Year.leap_year?(1997), "1997 is not a leap year."
   end
 
+  @tag :pending
   test "century" do
-    # assert ! Year.leap_year?(1900)
+    refute Year.leap_year?(1900), "1900 is not a leap year."
   end
 
+  @tag :pending
   test "exceptional century" do
-    # assert Year.leap_year?(2400)
+    assert Year.leap_year?(2400)
   end
 end

--- a/list-ops/list_ops_test.exs
+++ b/list-ops/list_ops_test.exs
@@ -5,6 +5,7 @@ else
 end
 
 ExUnit.start
+ExUnit.configure exclude: :pending
 
 defmodule ListOpsTest do
   alias ListOps, as: L
@@ -13,107 +14,132 @@ defmodule ListOpsTest do
 
   defp odd?(n), do: rem(n, 2) == 1
 
+  # @tag :pending
   test "count of empty list" do
     assert L.count([]) == 0
   end
 
+  @tag :pending
   test "count of normal list" do
     assert L.count([1,3,5,7]) == 4
   end
 
+  @tag :pending
   test "count of huge list" do
     assert L.count(Enum.to_list(1..1_000_000)) == 1_000_000
   end
 
+  @tag :pending
   test "reverse of empty list" do
     assert L.reverse([]) == []
   end
 
+  @tag :pending
   test "reverse of normal list" do
     assert L.reverse([1,3,5,7]) == [7,5,3,1]
   end
 
+  @tag :pending
   test "reverse of huge list" do
     assert L.reverse(Enum.to_list(1..1_000_000)) == Enum.to_list(1_000_000..1)
   end
 
+  @tag :pending
   test "map of empty list" do
     assert L.map([], &(&1+1)) == []
   end
 
+  @tag :pending
   test "map of normal list" do
     assert L.map([1,3,5,7], &(&1+1)) == [2,4,6,8]
   end
 
+  @tag :pending
   test "map of huge list" do
     assert L.map(Enum.to_list(1..1_000_000), &(&1+1)) ==
       Enum.to_list(2..1_000_001)
   end
 
+  @tag :pending
   test "filter of empty list" do
     assert L.filter([], &odd?/1) == []
   end
 
+  @tag :pending
   test "filter of normal list" do
     assert L.filter([1,2,3,4], &odd?/1) == [1,3]
   end
 
+  @tag :pending
   test "filter of huge list" do
     assert L.filter(Enum.to_list(1..1_000_000), &odd?/1) ==
       Enum.map(1..500_000, &(&1*2-1))
   end
 
+  @tag :pending
   test "reduce of empty list" do
     assert L.reduce([], 0, &(&1+&2)) == 0
   end
 
+  @tag :pending
   test "reduce of normal list" do
     assert L.reduce([1,2,3,4], -3, &(&1+&2)) == 7
   end
 
+  @tag :pending
   test "reduce of huge list" do
     assert L.reduce(Enum.to_list(1..1_000_000), 0, &(&1+&2)) ==
       Enum.reduce(1..1_000_000, 0, &(&1+&2))
   end
 
+  @tag :pending
   test "reduce with non-commutative function" do
     assert L.reduce([1,2,3,4], 10, fn x, acc -> acc - x end) == 0
   end
 
+  @tag :pending
   test "append of empty lists" do
     assert L.append([], []) == []
   end
 
+  @tag :pending
   test "append of empty and non-empty list" do
     assert L.append([], [1,2,3,4]) == [1,2,3,4]
   end
 
+  @tag :pending
   test "append of non-empty and empty list" do
     assert L.append([1,2,3,4], []) == [1,2,3,4]
   end
 
+  @tag :pending
   test "append of non-empty lists" do
     assert L.append([1,2,3], [4,5]) == [1,2,3,4,5]
   end
 
+  @tag :pending
   test "append of huge lists" do
     assert L.append(Enum.to_list(1..1_000_000), Enum.to_list(1_000_001..2_000_000)) ==
       Enum.to_list(1..2_000_000)
   end
 
+  @tag :pending
   test "concat of empty list of lists" do
     assert L.concat([]) == []
   end
 
+  @tag :pending
   test "concat of normal list of lists" do
     assert L.concat([[1,2],[3],[],[4,5,6]]) == [1,2,3,4,5,6]
   end
 
+  @tag :pending
   test "concat of huge list of small lists" do
     assert L.concat(Enum.map(1..1_000_000, &[&1])) ==
       Enum.to_list(1..1_000_000)
   end
 
+  @tag :pending
   test "concat of small list of huge lists" do
     assert L.concat(Enum.map(0..9, &Enum.to_list((&1*100_000+1)..((&1+1)*100_000)))) ==
       Enum.to_list(1..1_000_000)

--- a/meetup/meetup_test.exs
+++ b/meetup/meetup_test.exs
@@ -5,370 +5,462 @@ else
 end
 
 ExUnit.start
+ExUnit.configure exclude: :pending
 
 defmodule MeetupTest do
   use ExUnit.Case, async: false
 
+  # @tag :pending
   test "monteenth of may 2013" do
     assert Meetup.meetup(2013, 5, :monday, :teenth) == {2013, 5, 13}
   end
 
+  @tag :pending
   test "monteenth of august 2013" do
     assert Meetup.meetup(2013, 8, :monday, :teenth) == {2013, 8, 19}
   end
 
+  @tag :pending
   test "monteenth of september 2013" do
     assert Meetup.meetup(2013, 9, :monday, :teenth) == {2013, 9, 16}
   end
 
+  @tag :pending
   test "tuesteenth of march 2013" do
     assert Meetup.meetup(2013, 3, :tuesday, :teenth) == {2013, 3, 19}
   end
 
+  @tag :pending
   test "tuesteenth of april 2013" do
     assert Meetup.meetup(2013, 4, :tuesday, :teenth) == {2013, 4, 16}
   end
 
+  @tag :pending
   test "tuesteenth of august 2013" do
     assert Meetup.meetup(2013, 8, :tuesday, :teenth) == {2013, 8, 13}
   end
 
+  @tag :pending
   test "wednesteenth of january 2013" do
     assert Meetup.meetup(2013, 1, :wednesday, :teenth) == {2013, 1, 16}
   end
 
+  @tag :pending
   test "wednesteenth of february 2013" do
     assert Meetup.meetup(2013, 2, :wednesday, :teenth) == {2013, 2, 13}
   end
 
+  @tag :pending
   test "wednesteenth of june 2013" do
     assert Meetup.meetup(2013, 6, :wednesday, :teenth) == {2013, 6, 19}
   end
 
+  @tag :pending
   test "thursteenth of may 2013" do
     assert Meetup.meetup(2013, 5, :thursday, :teenth) == {2013, 5, 16}
   end
 
+  @tag :pending
   test "thursteenth of june 2013" do
     assert Meetup.meetup(2013, 6, :thursday, :teenth) == {2013, 6, 13}
   end
 
+  @tag :pending
   test "thursteenth of september 2013" do
     assert Meetup.meetup(2013, 9, :thursday, :teenth) == {2013, 9, 19}
   end
 
+  @tag :pending
   test "friteenth of april 2013" do
     assert Meetup.meetup(2013, 4, :friday, :teenth) == {2013, 4, 19}
   end
 
+  @tag :pending
   test "friteenth of august 2013" do
     assert Meetup.meetup(2013, 8, :friday, :teenth) == {2013, 8, 16}
   end
 
+  @tag :pending
   test "friteenth of september 2013" do
     assert Meetup.meetup(2013, 9, :friday, :teenth) == {2013, 9, 13}
   end
 
+  @tag :pending
   test "saturteenth of february 2013" do
     assert Meetup.meetup(2013, 2, :saturday, :teenth) == {2013, 2, 16}
   end
 
+  @tag :pending
   test "saturteenth of april 2013" do
     assert Meetup.meetup(2013, 4, :saturday, :teenth) == {2013, 4, 13}
   end
 
+  @tag :pending
   test "saturteenth of october 2013" do
     assert Meetup.meetup(2013, 10, :saturday, :teenth) == {2013, 10, 19}
   end
 
+  @tag :pending
   test "sunteenth of may 2013" do
     assert Meetup.meetup(2013, 5, :sunday, :teenth) == {2013, 5, 19}
   end
 
+  @tag :pending
   test "sunteenth of june 2013" do
     assert Meetup.meetup(2013, 6, :sunday, :teenth) == {2013, 6, 16}
   end
 
+  @tag :pending
   test "sunteenth of october 2013" do
     assert Meetup.meetup(2013, 10, :sunday, :teenth) == {2013, 10, 13}
   end
 
+  @tag :pending
   test "first monday of march 2013" do
     assert Meetup.meetup(2013, 3, :monday, :first) == {2013, 3, 4}
   end
 
+  @tag :pending
   test "first monday of april 2013" do
     assert Meetup.meetup(2013, 4, :monday, :first) == {2013, 4, 1}
   end
 
+  @tag :pending
   test "first tuesday of may 2013" do
     assert Meetup.meetup(2013, 5, :tuesday, :first) == {2013, 5, 7}
   end
 
+  @tag :pending
   test "first tuesday of june 2013" do
     assert Meetup.meetup(2013, 6, :tuesday, :first) == {2013, 6, 4}
   end
 
+  @tag :pending
   test "first wednesday of july 2013" do
     assert Meetup.meetup(2013, 7, :wednesday, :first) == {2013, 7, 3}
   end
 
+  @tag :pending
   test "first wednesday of august 2013" do
     assert Meetup.meetup(2013, 8, :wednesday, :first) == {2013, 8, 7}
   end
 
+  @tag :pending
   test "first thursday of september 2013" do
     assert Meetup.meetup(2013, 9, :thursday, :first) == {2013, 9, 5}
   end
 
+  @tag :pending
   test "first thursday of october 2013" do
     assert Meetup.meetup(2013, 10, :thursday, :first) == {2013, 10, 3}
   end
 
+  @tag :pending
   test "first friday of november 2013" do
     assert Meetup.meetup(2013, 11, :friday, :first) == {2013, 11, 1}
   end
 
+  @tag :pending
   test "first friday of december 2013" do
     assert Meetup.meetup(2013, 12, :friday, :first) == {2013, 12, 6}
   end
 
+  @tag :pending
   test "first saturday of january 2013" do
     assert Meetup.meetup(2013, 1, :saturday, :first) == {2013, 1, 5}
   end
 
+  @tag :pending
   test "first saturday of february 2013" do
     assert Meetup.meetup(2013, 2, :saturday, :first) == {2013, 2, 2}
   end
 
+  @tag :pending
   test "first sunday of march 2013" do
     assert Meetup.meetup(2013, 3, :sunday, :first) == {2013, 3, 3}
   end
 
+  @tag :pending
   test "first sunday of april 2013" do
     assert Meetup.meetup(2013, 4, :sunday, :first) == {2013, 4, 7}
   end
 
+  @tag :pending
   test "second monday of march 2013" do
     assert Meetup.meetup(2013, 3, :monday, :second) == {2013, 3, 11}
   end
 
+  @tag :pending
   test "second monday of april 2013" do
     assert Meetup.meetup(2013, 4, :monday, :second) == {2013, 4, 8}
   end
 
+  @tag :pending
   test "second tuesday of may 2013" do
     assert Meetup.meetup(2013, 5, :tuesday, :second) == {2013, 5, 14}
   end
 
+  @tag :pending
   test "second tuesday of june 2013" do
     assert Meetup.meetup(2013, 6, :tuesday, :second) == {2013, 6, 11}
   end
 
+  @tag :pending
   test "second wednesday of july 2013" do
     assert Meetup.meetup(2013, 7, :wednesday, :second) == {2013, 7, 10}
   end
 
+  @tag :pending
   test "second wednesday of august 2013" do
     assert Meetup.meetup(2013, 8, :wednesday, :second) == {2013, 8, 14}
   end
 
+  @tag :pending
   test "second thursday of september 2013" do
     assert Meetup.meetup(2013, 9, :thursday, :second) == {2013, 9, 12}
   end
 
+  @tag :pending
   test "second thursday of october 2013" do
     assert Meetup.meetup(2013, 10, :thursday, :second) == {2013, 10, 10}
   end
 
+  @tag :pending
   test "second friday of november 2013" do
     assert Meetup.meetup(2013, 11, :friday, :second) == {2013, 11, 8}
   end
 
+  @tag :pending
   test "second friday of december 2013" do
     assert Meetup.meetup(2013, 12, :friday, :second) == {2013, 12, 13}
   end
 
+  @tag :pending
   test "second saturday of january 2013" do
     assert Meetup.meetup(2013, 1, :saturday, :second) == {2013, 1, 12}
   end
 
+  @tag :pending
   test "second saturday of february 2013" do
     assert Meetup.meetup(2013, 2, :saturday, :second) == {2013, 2, 9}
   end
 
+  @tag :pending
   test "second sunday of march 2013" do
     assert Meetup.meetup(2013, 3, :sunday, :second) == {2013, 3, 10}
   end
 
+  @tag :pending
   test "second sunday of april 2013" do
     assert Meetup.meetup(2013, 4, :sunday, :second) == {2013, 4, 14}
   end
 
+  @tag :pending
   test "third monday of march 2013" do
     assert Meetup.meetup(2013, 3, :monday, :third) == {2013, 3, 18}
   end
 
+  @tag :pending
   test "third monday of april 2013" do
     assert Meetup.meetup(2013, 4, :monday, :third) == {2013, 4, 15}
   end
 
+  @tag :pending
   test "third tuesday of may 2013" do
     assert Meetup.meetup(2013, 5, :tuesday, :third) == {2013, 5, 21}
   end
 
+  @tag :pending
   test "third tuesday of june 2013" do
     assert Meetup.meetup(2013, 6, :tuesday, :third) == {2013, 6, 18}
   end
 
+  @tag :pending
   test "third wednesday of july 2013" do
     assert Meetup.meetup(2013, 7, :wednesday, :third) == {2013, 7, 17}
   end
 
+  @tag :pending
   test "third wednesday of august 2013" do
     assert Meetup.meetup(2013, 8, :wednesday, :third) == {2013, 8, 21}
   end
 
+  @tag :pending
   test "third thursday of september 2013" do
     assert Meetup.meetup(2013, 9, :thursday, :third) == {2013, 9, 19}
   end
 
+  @tag :pending
   test "third thursday of october 2013" do
     assert Meetup.meetup(2013, 10, :thursday, :third) == {2013, 10, 17}
   end
 
+  @tag :pending
   test "third friday of november 2013" do
     assert Meetup.meetup(2013, 11, :friday, :third) == {2013, 11, 15}
   end
 
+  @tag :pending
   test "third friday of december 2013" do
     assert Meetup.meetup(2013, 12, :friday, :third) == {2013, 12, 20}
   end
 
+  @tag :pending
   test "third saturday of january 2013" do
     assert Meetup.meetup(2013, 1, :saturday, :third) == {2013, 1, 19}
   end
 
+  @tag :pending
   test "third saturday of february 2013" do
     assert Meetup.meetup(2013, 2, :saturday, :third) == {2013, 2, 16}
   end
 
+  @tag :pending
   test "third sunday of march 2013" do
     assert Meetup.meetup(2013, 3, :sunday, :third) == {2013, 3, 17}
   end
 
+  @tag :pending
   test "third sunday of april 2013" do
     assert Meetup.meetup(2013, 4, :sunday, :third) == {2013, 4, 21}
   end
 
+  @tag :pending
   test "fourth monday of march 2013" do
     assert Meetup.meetup(2013, 3, :monday, :fourth) == {2013, 3, 25}
   end
 
+  @tag :pending
   test "fourth monday of april 2013" do
     assert Meetup.meetup(2013, 4, :monday, :fourth) == {2013, 4, 22}
   end
 
+  @tag :pending
   test "fourth tuesday of may 2013" do
     assert Meetup.meetup(2013, 5, :tuesday, :fourth) == {2013, 5, 28}
   end
 
+  @tag :pending
   test "fourth tuesday of june 2013" do
     assert Meetup.meetup(2013, 6, :tuesday, :fourth) == {2013, 6, 25}
   end
 
+  @tag :pending
   test "fourth wednesday of july 2013" do
     assert Meetup.meetup(2013, 7, :wednesday, :fourth) == {2013, 7, 24}
   end
 
+  @tag :pending
   test "fourth wednesday of august 2013" do
     assert Meetup.meetup(2013, 8, :wednesday, :fourth) == {2013, 8, 28}
   end
 
+  @tag :pending
   test "fourth thursday of september 2013" do
     assert Meetup.meetup(2013, 9, :thursday, :fourth) == {2013, 9, 26}
   end
 
+  @tag :pending
   test "fourth thursday of october 2013" do
     assert Meetup.meetup(2013, 10, :thursday, :fourth) == {2013, 10, 24}
   end
 
+  @tag :pending
   test "fourth friday of november 2013" do
     assert Meetup.meetup(2013, 11, :friday, :fourth) == {2013, 11, 22}
   end
 
+  @tag :pending
   test "fourth friday of december 2013" do
     assert Meetup.meetup(2013, 12, :friday, :fourth) == {2013, 12, 27}
   end
 
+  @tag :pending
   test "fourth saturday of january 2013" do
     assert Meetup.meetup(2013, 1, :saturday, :fourth) == {2013, 1, 26}
   end
 
+  @tag :pending
   test "fourth saturday of february 2013" do
     assert Meetup.meetup(2013, 2, :saturday, :fourth) == {2013, 2, 23}
   end
 
+  @tag :pending
   test "fourth sunday of march 2013" do
     assert Meetup.meetup(2013, 3, :sunday, :fourth) == {2013, 3, 24}
   end
 
+  @tag :pending
   test "fourth sunday of april 2013" do
     assert Meetup.meetup(2013, 4, :sunday, :fourth) == {2013, 4, 28}
   end
 
+  @tag :pending
   test "last monday of march 2013" do
     assert Meetup.meetup(2013, 3, :monday, :last) == {2013, 3, 25}
   end
 
+  @tag :pending
   test "last monday of april 2013" do
     assert Meetup.meetup(2013, 4, :monday, :last) == {2013, 4, 29}
   end
 
+  @tag :pending
   test "last tuesday of may 2013" do
     assert Meetup.meetup(2013, 5, :tuesday, :last) == {2013, 5, 28}
   end
 
+  @tag :pending
   test "last tuesday of june 2013" do
     assert Meetup.meetup(2013, 6, :tuesday, :last) == {2013, 6, 25}
   end
 
+  @tag :pending
   test "last wednesday of july 2013" do
     assert Meetup.meetup(2013, 7, :wednesday, :last) == {2013, 7, 31}
   end
 
+  @tag :pending
   test "last wednesday of august 2013" do
     assert Meetup.meetup(2013, 8, :wednesday, :last) == {2013, 8, 28}
   end
 
+  @tag :pending
   test "last thursday of september 2013" do
     assert Meetup.meetup(2013, 9, :thursday, :last) == {2013, 9, 26}
   end
 
+  @tag :pending
   test "last thursday of october 2013" do
     assert Meetup.meetup(2013, 10, :thursday, :last) == {2013, 10, 31}
   end
 
+  @tag :pending
   test "last friday of november 2013" do
     assert Meetup.meetup(2013, 11, :friday, :last) == {2013, 11, 29}
   end
 
+  @tag :pending
   test "last friday of december 2013" do
     assert Meetup.meetup(2013, 12, :friday, :last) == {2013, 12, 27}
   end
 
+  @tag :pending
   test "last saturday of january 2013" do
     assert Meetup.meetup(2013, 1, :saturday, :last) == {2013, 1, 26}
   end
 
+  @tag :pending
   test "last saturday of february 2013" do
     assert Meetup.meetup(2013, 2, :saturday, :last) == {2013, 2, 23}
   end
 
+  @tag :pending
   test "last sunday of march 2013" do
     assert Meetup.meetup(2013, 3, :sunday, :last) == {2013, 3, 31}
   end
 
+  @tag :pending
   test "last sunday of april 2013" do
     assert Meetup.meetup(2013, 4, :sunday, :last) == {2013, 4, 28}
   end

--- a/minesweeper/minesweeper_test.exs
+++ b/minesweeper/minesweeper_test.exs
@@ -5,17 +5,20 @@ else
 end
 
 ExUnit.start
+ExUnit.configure exclude: :pending
 
 defmodule MinesweeperTest do
   use ExUnit.Case, async: true
 
   defp clean(b), do: Enum.map(b, &String.replace(&1, ~r/[^*]/, " "))
 
+  # @tag :pending
   test "zero size board" do
     b = []
     assert Minesweeper.annotate(clean(b)) == b
   end
 
+  @tag :pending
   test "empty board" do
     b = ["   ",
          "   ",
@@ -23,6 +26,7 @@ defmodule MinesweeperTest do
     assert Minesweeper.annotate(clean(b)) == b
   end
 
+  @tag :pending
   test "board full of mines" do
     b = ["***",
          "***",
@@ -30,6 +34,7 @@ defmodule MinesweeperTest do
     assert Minesweeper.annotate(clean(b)) == b
   end
 
+  @tag :pending
   test "surrounded" do
     b = ["***",
          "*8*",
@@ -37,11 +42,13 @@ defmodule MinesweeperTest do
     assert Minesweeper.annotate(clean(b)) == b
   end
 
+  @tag :pending
   test "horizontal line" do
     b = ["1*2*1"]
     assert Minesweeper.annotate(clean(b)) == b
   end
 
+  @tag :pending
   test "vertical line" do
     b = ["1",
          "*",
@@ -51,6 +58,7 @@ defmodule MinesweeperTest do
     assert Minesweeper.annotate(clean(b)) == b
   end
 
+  @tag :pending
   test "cross" do
     b = [" 2*2 ",
          "25*52",
@@ -58,5 +66,5 @@ defmodule MinesweeperTest do
          "25*52",
          " 2*2 "]
     assert Minesweeper.annotate(clean(b)) == b
-  end        
+  end
 end

--- a/nth-prime/nth_prime_test.exs
+++ b/nth-prime/nth_prime_test.exs
@@ -5,28 +5,33 @@ else
 end
 
 ExUnit.start
+ExUnit.configure exclude: :pending
 
 defmodule NthPrimeTest do
   use ExUnit.Case, async: true
 
+  # @tag :pending
   test "first prime" do
     assert Prime.nth(1) == 2
   end
 
+  @tag :pending
   test "second prime" do
     assert Prime.nth(2) == 3
   end
 
+  @tag :pending
   test "sixth prime" do
     assert Prime.nth(6) == 13
   end
 
+  @tag :pending
   test "100th prime" do
     assert Prime.nth(100) == 541
   end
 
+  @tag :pending
   test "weird case" do
     catch_error Prime.nth(0)
   end
-
 end

--- a/nucleotide-count/nucleotide_count_test.exs
+++ b/nucleotide-count/nucleotide_count_test.exs
@@ -5,36 +5,44 @@ else
 end
 
 ExUnit.start
+ExUnit.configure
 
 defmodule DNATest do
   use ExUnit.Case, async: true
 
+  # @tag :pending
   test "empty dna string has no adenosine" do
     assert DNA.count('', ?A) == 0
   end
 
+  @tag :pending
   test "empty dna string has no nucleotides" do
     expected = %{?A => 0, ?T => 0, ?C => 0, ?G => 0}
     assert DNA.nucleotide_counts('') == expected
   end
 
+  @tag :pending
   test "repetitive cytidine gets counted" do
     assert DNA.count('CCCCC', ?C) == 5
   end
 
+  @tag :pending
   test "repetitive sequence has only guanosine" do
     expected = %{?A => 0, ?T => 0, ?C => 0, ?G => 8}
     assert DNA.nucleotide_counts('GGGGGGGG') == expected
   end
 
+  @tag :pending
   test "counts only thymidine" do
     assert DNA.count('GGGGGTAACCCGG', ?T) == 1
   end
 
+  @tag :pending
   test "dna has no uracil" do
     assert DNA.count('GATTACA', ?U) == 0
   end
 
+  @tag :pending
   test "counts all nucleotides" do
     s = 'AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC'
     expected = %{?A => 20, ?T => 21, ?C => 12, ?G => 17}

--- a/nucleotide-count/nucleotide_count_test.exs
+++ b/nucleotide-count/nucleotide_count_test.exs
@@ -5,7 +5,7 @@ else
 end
 
 ExUnit.start
-ExUnit.configure
+ExUnit.configure exclude: :pending
 
 defmodule DNATest do
   use ExUnit.Case, async: true

--- a/palindrome-products/palindrome_products_test.exs
+++ b/palindrome-products/palindrome_products_test.exs
@@ -5,34 +5,40 @@ else
 end
 
 ExUnit.start
+ExUnit.configure exclude: :pending
 
 defmodule PalindromeProductsTest do
   use ExUnit.Case, async: true
 
+  # @tag :pending
   test "largest palindrome from single digit factors" do
     palindromes = Palindromes.generate(9)
     assert palindromes |> Dict.keys |> Enum.sort |> List.last == 9
     assert palindromes[9] == [[1, 9], [3, 3]]
   end
 
+  @tag :pending
   test "largest palindrome from double digit factors" do
     palindromes = Palindromes.generate(99, 10)
     assert palindromes |> Dict.keys |> Enum.sort |> List.last == 9009
     assert palindromes[9009] == [[91, 99]]
   end
 
+  @tag :pending
   test "smallest palindrome from double digit factors" do
     palindromes = Palindromes.generate(99, 10)
     assert palindromes |> Dict.keys |> Enum.sort |> hd == 121
     assert palindromes[121] == [[11, 11]]
   end
 
+  @tag :pending
   test "largest palindrome from triple digit factors" do
     palindromes = Palindromes.generate(999, 100)
     assert palindromes |> Dict.keys |> Enum.sort |> List.last == 906609
     assert palindromes[906609] == [[913, 993]]
   end
 
+  @tag :pending
   test "smallest palindromes from triple digit factors" do
     palindromes = Palindromes.generate(999, 100)
     assert palindromes |> Dict.keys |> Enum.sort |> hd == 10201

--- a/parallel-letter-frequency/parallel_letter_frequency_test.exs
+++ b/parallel-letter-frequency/parallel_letter_frequency_test.exs
@@ -5,6 +5,7 @@ else
 end
 
 ExUnit.start
+ExUnit.configure exclude: :pending
 
 # Your code should contain a frequency(texts, workers) function which accepts a
 # list of texts and the number of workers to use in parallel.
@@ -55,35 +56,43 @@ defmodule FrequencyTest do
     Frequency.frequency(texts, workers) |> Enum.sort() |> Enum.into(%{})
   end
 
+  # @tag :pending
   test "no texts mean no letters" do
     assert freq([]) == %{}
   end
 
+  @tag :pending
   test "one letter" do
     assert freq(["a"]) == %{"a" => 1}
   end
 
+  @tag :pending
   test "case insensitivity" do
     assert freq(["aA"]) == %{"a" => 2}
   end
 
+  @tag :pending
   test "many empty texts still mean no letters" do
     assert freq(List.duplicate("  ", 10000)) == %{}
   end
 
+  @tag :pending
   test "many times the same text gives a predictable result" do
     assert freq(List.duplicate("abc", 1000))
          == %{"a" => 1000, "b" => 1000, "c" => 1000}
   end
 
+  @tag :pending
   test "punctuation doesn't count" do
     assert freq([@ode_an_die_freude])[","] == nil
   end
 
+  @tag :pending
   test "numbers don't count" do
     assert freq(["Testing, 1, 2, 3"])["1"] == nil
   end
 
+  @tag :pending
   test "all three anthems, together, 1 worker" do
     freqs = freq([@ode_an_die_freude, @wilhelmus, @star_spangled_banner], 1)
     assert freqs["a"] == 49
@@ -91,6 +100,7 @@ defmodule FrequencyTest do
     assert freqs["ü"] == 2
   end
 
+  @tag :pending
   test "all three anthems, together, 4 workers" do
     freqs = freq([@ode_an_die_freude, @wilhelmus, @star_spangled_banner], 4)
     assert freqs["a"] == 49

--- a/phone-number/phone_number_test.exs
+++ b/phone-number/phone_number_test.exs
@@ -13,7 +13,7 @@ defmodule PhoneTest do
   test "cleans number" do
     assert Phone.number("(123) 456-7890") == "1234567890"
   end
-  
+
   @tag :pending
   test "cleans number with dots" do
     assert Phone.number("123.456.7890") == "1234567890"
@@ -23,12 +23,12 @@ defmodule PhoneTest do
   test "valid when 11 digits and first is 1" do
     assert Phone.number("11234567890") == "1234567890"
   end
-  
+
   @tag :pending
   test "invalid when 11 digits" do
     assert Phone.number("21234567890") == "0000000000"
   end
-  
+
   @tag :pending
   test "invalid when 9 digits" do
     assert Phone.number("123456789") == "0000000000"
@@ -38,22 +38,22 @@ defmodule PhoneTest do
   test "invalid when proper number of digits but letters mixed in" do
     assert Phone.number("1a2a3a4a5a6a7a8a9a0a") == "0000000000"
   end
-  
+
   @tag :pending
   test "area code" do
     assert Phone.area_code("1234567890") == "123"
   end
-  
+
   @tag :pending
   test "area code with full US phone number" do
     assert Phone.area_code("11234567890") == "123"
   end
-  
+
   @tag :pending
   test "pretty print" do
     assert Phone.pretty("1234567890") == "(123) 456-7890"
   end
-  
+
   @tag :pending
   test "pretty print with full US phone number" do
     assert Phone.pretty("11234567890") == "(123) 456-7890"

--- a/point-mutations/point_mutations_test.exs
+++ b/point-mutations/point_mutations_test.exs
@@ -5,26 +5,32 @@ else
 end
 
 ExUnit.start
+ExUnit.configure exclude: :pending
 
 defmodule DNATest do
   use ExUnit.Case, async: true
 
+  # @tag :pending
   test "no difference between empty strands" do
     assert DNA.hamming_distance('', '') == 0
   end
 
+  @tag :pending
   test "no difference between identical strands" do
     assert DNA.hamming_distance('GGACTGA', 'GGACTGA') == 0
   end
 
+  @tag :pending
   test "small hamming distance in middle somewhere" do
     assert DNA.hamming_distance('GGACG', 'GGTCG') == 1
   end
 
+  @tag :pending
   test "larger distance" do
     assert DNA.hamming_distance('ACCAGGG', 'ACTATGG') == 2
   end
 
+  @tag :pending
   test "hamming distance is undefined for strands of different lengths" do
     assert DNA.hamming_distance('AAAC', 'TAGGGGAGGCTAGCGGTAGGAC') == nil
     assert DNA.hamming_distance('GACTACGGACAGGACACC', 'GACATCGC') == nil

--- a/prime-factors/prime_factors_test.exs
+++ b/prime-factors/prime_factors_test.exs
@@ -5,50 +5,62 @@ else
 end
 
 ExUnit.start
+ExUnit.configure exclude: :pending
 
 defmodule PrimeFactorsTest do
   use ExUnit.Case, async: true
 
+  # @tag :pending
   test "1" do
     assert PrimeFactors.factors_for(1) == []
   end
 
+  @tag :pending
   test "2" do
     assert PrimeFactors.factors_for(2) == [2]
   end
 
+  @tag :pending
   test "3" do
     assert PrimeFactors.factors_for(3) == [3]
   end
 
+  @tag :pending
   test "4" do
     assert PrimeFactors.factors_for(4) == [2, 2]
   end
 
+  @tag :pending
   test "6" do
     assert PrimeFactors.factors_for(6) == [2, 3]
   end
 
+  @tag :pending
   test "8" do
     assert PrimeFactors.factors_for(8) == [2, 2, 2]
   end
 
+  @tag :pending
   test "9" do
     assert PrimeFactors.factors_for(9) == [3, 3]
   end
 
+  @tag :pending
   test "27" do
     assert PrimeFactors.factors_for(27) == [3, 3, 3]
   end
 
+  @tag :pending
   test "625" do
     assert PrimeFactors.factors_for(625) == [5, 5, 5, 5]
   end
 
+  @tag :pending
   test "901255" do
     assert PrimeFactors.factors_for(901255) == [5, 17, 23, 461]
   end
 
+  @tag :pending
   test "93819012551" do
     assert PrimeFactors.factors_for(93819012551) == [11, 9539, 894119]
   end

--- a/pythagorean-triplet/pythagorean_triplet_test.exs
+++ b/pythagorean-triplet/pythagorean_triplet_test.exs
@@ -5,40 +5,48 @@ else
 end
 
 ExUnit.start
+ExUnit.configure exclude: :pending
 
 defmodule PythagoreanTripletTest do
   use ExUnit.Case, async: true
 
+  # @tag :pending
   test "sum" do
     triplet = [3, 4, 5]
     assert Triplet.sum(triplet) == 12
   end
 
+  @tag :pending
   test "product" do
     triplet = [3, 4, 5]
     assert Triplet.product(triplet) == 60
   end
 
+  @tag :pending
   test "pythagorean" do
     triplet = [3, 4, 5]
     assert Triplet.pythagorean?(triplet)
   end
 
+  @tag :pending
   test "not pythagorean" do
     triplet = [5, 6, 7]
     refute Triplet.pythagorean?(triplet)
   end
 
+  @tag :pending
   test "triplets up to 10" do
     triplets = Triplet.generate(1, 10)
     assert Enum.map(triplets, &Triplet.product/1) == [60, 480]
   end
 
+  @tag :pending
   test "triplets from 11 up to 20" do
     triplets = Triplet.generate(11, 20)
     assert Enum.map(triplets, &Triplet.product/1) == [3840]
   end
 
+  @tag :pending
   test "triplets where sum is 180 and max factor is 100" do
     triplets = Triplet.generate(1, 100, 180)
     assert Enum.map(triplets, &Triplet.product/1) == [118080, 168480, 202500]

--- a/raindrops/raindrops_test.exs
+++ b/raindrops/raindrops_test.exs
@@ -5,70 +5,87 @@ else
 end
 
 ExUnit.start
+ExUnit.configure exclude: :pending
 
 defmodule RaindropsTest do
   use ExUnit.Case, async: true
 
+  # @tag :pending
   test "1" do
     assert Raindrops.convert(1) == "1"
   end
 
+  @tag :pending
   test "3" do
     assert Raindrops.convert(3) == "Pling"
   end
 
+  @tag :pending
   test "5" do
     assert Raindrops.convert(5) == "Plang"
   end
 
+  @tag :pending
   test "7" do
     assert Raindrops.convert(7) == "Plong"
   end
 
+  @tag :pending
   test "6" do
     assert Raindrops.convert(6) == "Pling"
   end
 
+  @tag :pending
   test "9" do
     assert Raindrops.convert(9) == "Pling"
   end
 
+  @tag :pending
   test "10" do
     assert Raindrops.convert(10) == "Plang"
   end
 
+  @tag :pending
   test "14" do
     assert Raindrops.convert(14) == "Plong"
   end
 
+  @tag :pending
   test "15" do
     assert Raindrops.convert(15) == "PlingPlang"
   end
 
+  @tag :pending
   test "21" do
     assert Raindrops.convert(21) == "PlingPlong"
   end
 
+  @tag :pending
   test "25" do
     assert Raindrops.convert(25) == "Plang"
   end
 
+  @tag :pending
   test "35" do
     assert Raindrops.convert(35) == "PlangPlong"
   end
 
+  @tag :pending
   test "49" do
     assert Raindrops.convert(49) == "Plong"
   end
 
+  @tag :pending
   test "52" do
     assert Raindrops.convert(52) == "52"
   end
 
+  @tag :pending
   test "105" do
     assert Raindrops.convert(105) == "PlingPlangPlong"
   end
 
+  @tag :pending
   test "12121" do
     assert Raindrops.convert(12121) == "12121"
   end

--- a/rna-transcription/rna_transcription_test.exs
+++ b/rna-transcription/rna_transcription_test.exs
@@ -5,26 +5,32 @@ else
 end
 
 ExUnit.start
+ExUnit.configure exclude: :pending
 
 defmodule DNATest do
   use ExUnit.Case, async: true
 
+  # @tag :pending
   test "transcribes guanine to cytosine" do
     assert DNA.to_rna('G') == 'C'
   end
 
+  @tag :pending
   test "transcribes cytosine to guanine" do
     assert DNA.to_rna('C') == 'G'
   end
 
+  @tag :pending
   test "transcribes thymidine to adenine" do
     assert DNA.to_rna('T') == 'A'
   end
 
+  @tag :pending
   test "transcribes adenine to uracil" do
     assert DNA.to_rna('A') == 'U'
   end
 
+  @tag :pending
   test "it transcribes all dna nucleotides to rna equivalents" do
     assert DNA.to_rna('ACGTGGTCTTAA') == 'UGCACCAGAAUU'
   end

--- a/roman-numerals/roman_numerals_test.exs
+++ b/roman-numerals/roman_numerals_test.exs
@@ -5,78 +5,97 @@ else
 end
 
 ExUnit.start
+ExUnit.configure exclude: :pending
 
 defmodule RomanTest do
   use ExUnit.Case, async: true
 
+  # @tag :pending
   test "1" do
     assert Roman.numerals(1) == "I"
   end
 
+  @tag :pending
   test "2" do
     assert Roman.numerals(2) == "II"
   end
 
+  @tag :pending
   test "3" do
     assert Roman.numerals(3) == "III"
   end
 
+  @tag :pending
   test "4" do
     assert Roman.numerals(4) == "IV"
   end
 
+  @tag :pending
   test "5" do
     assert Roman.numerals(5) == "V"
   end
 
+  @tag :pending
   test "6" do
     assert Roman.numerals(6) == "VI"
   end
 
+  @tag :pending
   test "9" do
     assert Roman.numerals(9) == "IX"
   end
 
+  @tag :pending
   test "27" do
     assert Roman.numerals(27) == "XXVII"
   end
 
+  @tag :pending
   test "48" do
     assert Roman.numerals(48) == "XLVIII"
   end
 
+  @tag :pending
   test "59" do
     assert Roman.numerals(59) == "LIX"
   end
 
+  @tag :pending
   test "93" do
     assert Roman.numerals(93) == "XCIII"
   end
 
+  @tag :pending
   test "141" do
     assert Roman.numerals(141) == "CXLI"
   end
 
+  @tag :pending
   test "163" do
     assert Roman.numerals(163) == "CLXIII"
   end
 
+  @tag :pending
   test "402" do
     assert Roman.numerals(402) == "CDII"
   end
 
+  @tag :pending
   test "575" do
     assert Roman.numerals(575) == "DLXXV"
   end
 
+  @tag :pending
   test "911" do
     assert Roman.numerals(911) == "CMXI"
   end
 
+  @tag :pending
   test "1024" do
     assert Roman.numerals(1024) == "MXXIV"
   end
 
+  @tag :pending
   test "3000" do
     assert Roman.numerals(3000) == "MMM"
   end

--- a/scrabble-score/scrabble_score_test.exs
+++ b/scrabble-score/scrabble_score_test.exs
@@ -5,38 +5,47 @@ else
 end
 
 ExUnit.start
+ExUnit.configure exclude: :pending
 
 defmodule ScrabbleScoreTest do
   use ExUnit.Case, async: true
 
+  # @tag :pending
   test "empty word scores zero" do
     assert Scrabble.score("") == 0
   end
 
+  @tag :pending
   test "whitespace scores zero" do
     assert Scrabble.score(" \t\n") == 0
   end
 
+  @tag :pending
   test "scores very short word" do
     assert Scrabble.score("a") == 1
   end
 
+  @tag :pending
   test "scores other very short word" do
     assert Scrabble.score("f") == 4
   end
 
+  @tag :pending
   test "simple word scores the number of letters" do
     assert Scrabble.score("street") == 6
   end
 
+  @tag :pending
   test "complicated word scores more" do
     assert Scrabble.score("quirky") == 22
   end
 
+  @tag :pending
   test "scores are case insensitive" do
     assert Scrabble.score("MULTIBILLIONAIRE") == 20
   end
 
+  @tag :pending
   test "convenient scoring" do
     assert Scrabble.score("alacrity") == 13
   end

--- a/sieve/sieve_test.exs
+++ b/sieve/sieve_test.exs
@@ -5,14 +5,17 @@ else
 end
 
 ExUnit.start
+ExUnit.configure exclude: :pending
 
 defmodule SieveTest do
   use ExUnit.Case, async: true
 
+  # @tag :pending
   test "a few primes" do
     assert Sieve.primes_to(10) == [2, 3, 5, 7]
   end
 
+  @tag :pending
   test "primes to 1000" do
     result = [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37,
     41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83,

--- a/space-age/space_age_test.exs
+++ b/space-age/space_age_test.exs
@@ -5,6 +5,7 @@ else
 end
 
 ExUnit.start
+ExUnit.configure exclude: :pending
 
 # You need to define a SpaceAge module containing a function age_on that given a
 # planet (:earth, :saturn, etc) and a number of seconds returns the age in years
@@ -13,47 +14,55 @@ ExUnit.start
 defmodule SpageAgeTest do
   use ExUnit.Case, async: true
 
+  # @tag :pending
   test "age on Earth" do
     input = 1_000_000_000
     assert_in_delta 31.69, SpaceAge.age_on(:earth, input), 0.005
   end
 
+  @tag :pending
   test "age on Mercury" do
     input = 2_134_835_688
     assert_in_delta 67.65, SpaceAge.age_on(:earth, input), 0.005
     assert_in_delta 280.88, SpaceAge.age_on(:mercury, input), 0.005
   end
 
+  @tag :pending
   test "age on Venus" do
     input = 189_839_836
     assert_in_delta 6.02, SpaceAge.age_on(:earth, input), 0.005
     assert_in_delta 9.78, SpaceAge.age_on(:venus, input), 0.005
   end
 
+  @tag :pending
   test "age on Mars" do
     input = 2_329_871_239
     assert_in_delta 73.83, SpaceAge.age_on(:earth, input), 0.005
     assert_in_delta 39.25, SpaceAge.age_on(:mars, input), 0.005
   end
 
+  @tag :pending
   test "age on Jupiter" do
     input = 901_876_382
     assert_in_delta 28.58, SpaceAge.age_on(:earth, input), 0.005
     assert_in_delta 2.41, SpaceAge.age_on(:jupiter, input), 0.005
   end
 
+  @tag :pending
   test "age on Saturn" do
     input = 3_000_000_000
     assert_in_delta 95.06, SpaceAge.age_on(:earth, input), 0.005
     assert_in_delta 3.23, SpaceAge.age_on(:saturn, input), 0.005
   end
 
+  @tag :pending
   test "age on Uranus" do
     input = 3_210_123_456
     assert_in_delta 101.72, SpaceAge.age_on(:earth, input), 0.005
     assert_in_delta 1.21, SpaceAge.age_on(:uranus, input), 0.005
   end
 
+  @tag :pending
   test "age on Neptune" do
     input = 8_210_123_456
     assert_in_delta 260.16, SpaceAge.age_on(:earth, input), 0.005

--- a/sum-of-multiples/sum_of_multiples_test.exs
+++ b/sum-of-multiples/sum_of_multiples_test.exs
@@ -5,34 +5,40 @@ else
 end
 
 ExUnit.start
+ExUnit.configure exclude: :pending
 
 defmodule SumOfMultiplesTest do
   use ExUnit.Case, async: true
 
+  # @tag :pending
   test "sum to 1" do
     assert SumOfMultiples.to(1) == 0
   end
 
+  @tag :pending
   test "sum to 3" do
     assert SumOfMultiples.to(4) == 3
   end
 
+  @tag :pending
   test "sum to 10" do
     assert SumOfMultiples.to(10) == 23
   end
 
+  @tag :pending
   test "sum to 1000" do
     assert SumOfMultiples.to(1000) == 233168
   end
 
+  @tag :pending
   test "configurable 7, 13, 17 to 20" do
     multiples = [7, 13, 17]
     assert SumOfMultiples.to(20, multiples) == 51
   end
 
+  @tag :pending
   test "configurable 43, 47 to 10000" do
     multiples = [43, 47]
     assert SumOfMultiples.to(10000, multiples) == 2203160
   end
-
 end

--- a/triangle/triangle_test.exs
+++ b/triangle/triangle_test.exs
@@ -5,66 +5,82 @@ else
 end
 
 ExUnit.start
+ExUnit.configure exclude: :pending
 
 defmodule TriangleTest do
   use ExUnit.Case, async: true
 
+  # @tag :pending
   test "equilateral triangles have equal sides" do
     assert Triangle.kind(2, 2, 2) == { :ok, :equilateral }
   end
 
+  @tag :pending
   test "larger equilateral triangles also have equal sides" do
     assert Triangle.kind(10, 10, 10) == { :ok, :equilateral }
   end
 
+  @tag :pending
   test "isosceles triangles have last two sides equal" do
     assert Triangle.kind(3, 4, 4) == { :ok, :isosceles }
   end
 
+  @tag :pending
   test "isosceles triangles have first and last sides equal" do
     assert Triangle.kind(4, 3, 4) == { :ok, :isosceles }
   end
 
+  @tag :pending
   test "isosceles triangles have two first sides equal" do
     assert Triangle.kind(4, 4, 3) == { :ok, :isosceles }
   end
 
+  @tag :pending
   test "isosceles triangles have in fact exactly two sides equal" do
     assert Triangle.kind(10, 10, 2) == { :ok, :isosceles }
   end
 
+  @tag :pending
   test "scalene triangles have no equal sides" do
     assert Triangle.kind(3, 4, 5) == { :ok, :scalene }
   end
 
+  @tag :pending
   test "scalene triangles have no equal sides at a larger scale too" do
     assert Triangle.kind(10, 11, 12) == { :ok, :scalene }
   end
 
+  @tag :pending
   test "scalene triangles have no equal sides in descending order either" do
     assert Triangle.kind(5, 4, 2) == { :ok, :scalene }
   end
 
+  @tag :pending
   test "very small triangles are legal" do
     assert Triangle.kind(0.4, 0.6, 0.3) == { :ok, :scalene }
   end
 
+  @tag :pending
   test "triangles with no size are illegal" do
     assert Triangle.kind(0, 0, 0) == { :error, "all side lengths must be positive" }
   end
 
+  @tag :pending
   test "triangles with negative sides are illegal" do
     assert Triangle.kind(3, 4, -5) == { :error, "all side lengths must be positive" }
   end
 
+  @tag :pending
   test "triangles violating triangle inequality are illegal" do
     assert Triangle.kind(1, 1, 3) == { :error, "side lengths violate triangle inequality" }
   end
 
+  @tag :pending
   test "triangles violating triangle inequality are illegal 2" do
     assert Triangle.kind(2, 4, 2) == { :error, "side lengths violate triangle inequality" }
   end
 
+  @tag :pending
   test "triangles violating triangle inequality are illegal 3" do
     assert Triangle.kind(7, 3, 2) == { :error, "side lengths violate triangle inequality" }
   end

--- a/zipper/zipper_test.exs
+++ b/zipper/zipper_test.exs
@@ -5,11 +5,12 @@ else
 end
 
 ExUnit.start
+ExUnit.configure exclude: :pending
 
 defmodule ZipperTest do
   alias BinTree, as: BT
   import Zipper
- 
+
   # A custom inspect instance purely for the tests, this makes error messages
   # much more readable.
   #
@@ -26,7 +27,7 @@ defmodule ZipperTest do
   end
 
   use ExUnit.Case, async: false
-  
+
   defp bt(value, left, right), do: %BT{value: value, left: left, right: right}
   defp leaf(value), do: %BT{value: value}
 
@@ -37,34 +38,42 @@ defmodule ZipperTest do
   defp t5, do: bt(1, bt(2, nil, leaf(3)),
                      bt(6, leaf(7), leaf(8)))
 
+  # @tag :pending
   test "data is retained" do
     assert (t1 |> from_tree |> to_tree) == t1
   end
-  
+
+  @tag :pending
   test "left, right and value" do
     assert (t1 |> from_tree |> left |> right |> value) == 3
   end
-  
+
+  @tag :pending
   test "dead end" do
     assert (t1 |> from_tree |> left |> left) == nil
   end
 
+  @tag :pending
   test "tree from deep focus" do
     assert (t1 |> from_tree |> left |> right |> to_tree) == t1
   end
 
+  @tag :pending
   test "set_value" do
     assert (t1 |> from_tree |> left |> set_value(5) |> to_tree) == t2
   end
-  
+
+  @tag :pending
   test "set_left with leaf" do
     assert (t1 |> from_tree |> left |> set_left(leaf(5)) |> to_tree) == t3
   end
-  
+
+  @tag :pending
   test "set_right with nil" do
     assert (t1 |> from_tree |> left |> set_right(nil) |> to_tree) == t4
   end
-  
+
+  @tag :pending
   test "set_right with subtree" do
     assert (t1 |> from_tree |> set_right(bt(6, leaf(7), leaf(8))) |> to_tree) == t5
   end


### PR DESCRIPTION
… each test file for test files that did not have this. I found that running the test files for new exercises and seeing a bunch of failed tests especially when there are a lot of them was particularly unhelpful.

So I added
    ExUnit.configure exclude: :pending

to the test files under ExUnit.start and added '@tag :pending' to all the test files except the first test of each test file so that the tests can be easily run and the output easily read.