### PR TITLE
Replace 'Teenager' with 'Bob'

### DIFF
--- a/bob/bob.exs
+++ b/bob/bob.exs
@@ -1,4 +1,4 @@
-defmodule Teenager do
+defmodule Bob do
   def hey(input) do
     cond do
         true -> raise "Your implementation goes here"

--- a/bob/bob_test.exs
+++ b/bob/bob_test.exs
@@ -7,76 +7,76 @@ end
 ExUnit.start
 ExUnit.configure(exclude: :pending)
 
-defmodule TeenagerTest do
+defmodule BobTest do
   use ExUnit.Case, async: true
 
   test "stating something" do
-    assert Teenager.hey("Tom-ay-to, tom-aaaah-to.") == "Whatever."
+    assert Bob.hey("Tom-ay-to, tom-aaaah-to.") == "Whatever."
   end
 
   @tag :pending
   test "shouting" do
-    assert Teenager.hey("WATCH OUT!") == "Whoa, chill out!"
+    assert Bob.hey("WATCH OUT!") == "Whoa, chill out!"
   end
 
   @tag :pending
   test "asking a question" do
-    assert Teenager.hey("Does this cryogenic chamber make me look fat?") == "Sure."
+    assert Bob.hey("Does this cryogenic chamber make me look fat?") == "Sure."
   end
 
   @tag :pending
   test "talking forcefully" do
-    assert Teenager.hey("Let's go make out behind the gym!") == "Whatever."
+    assert Bob.hey("Let's go make out behind the gym!") == "Whatever."
   end
 
   @tag :pending
   test "talking in capitals" do
-    assert Teenager.hey("This Isn't Shouting!") == "Whatever."
+    assert Bob.hey("This Isn't Shouting!") == "Whatever."
   end
 
   @tag :pending
   test "shouting numbers" do
-    assert Teenager.hey("1, 2, 3 GO!") == "Whoa, chill out!"
+    assert Bob.hey("1, 2, 3 GO!") == "Whoa, chill out!"
   end
 
   @tag :pending
   test "shouting with special characters" do
-    assert Teenager.hey("ZOMG THE %^*@#$(*^ ZOMBIES ARE COMING!!11!!1!") == "Whoa, chill out!"
+    assert Bob.hey("ZOMG THE %^*@#$(*^ ZOMBIES ARE COMING!!11!!1!") == "Whoa, chill out!"
   end
 
   @tag :pending
   test "shouting with no exclamation mark" do
-    assert Teenager.hey("I HATE YOU") == "Whoa, chill out!"
+    assert Bob.hey("I HATE YOU") == "Whoa, chill out!"
   end
 
   @tag :pending
   test "statement containing question mark" do
-    assert Teenager.hey("Ending with ? means a question.") == "Whatever."
+    assert Bob.hey("Ending with ? means a question.") == "Whatever."
   end
 
   @tag :pending
   test "silence" do
-    assert Teenager.hey("") == "Fine. Be that way!"
+    assert Bob.hey("") == "Fine. Be that way!"
   end
 
   @tag :pending
   test "prolonged silence" do
-    assert Teenager.hey("  ") == "Fine. Be that way!"
+    assert Bob.hey("  ") == "Fine. Be that way!"
   end
 
   @tag :pending
   test "only numbers" do
-    assert Teenager.hey("1, 2, 3") == "Whatever."
+    assert Bob.hey("1, 2, 3") == "Whatever."
   end
 
   @tag :pending
   test "question with numbers" do
-    assert Teenager.hey("4?") == "Sure."
+    assert Bob.hey("4?") == "Sure."
   end
 
   @tag :pending
   test "shouting in Russian" do
     # Hopefully this is Russian for "GET OUT"
-    assert Teenager.hey("УХОДИТЬ") == "Whoa, chill out!"
+    assert Bob.hey("УХОДИТЬ") == "Whoa, chill out!"
   end
 end

--- a/bob/example.exs
+++ b/bob/example.exs
@@ -1,19 +1,19 @@
-defmodule Teenager do
+defmodule Bob do
   @doc """
   Answers to `hey` like a teenager.
 
   ## Examples
 
-  iex> Teenager.hey("")
+  iex> Bob.hey("")
   "Fine. Be that way!"
 
-  iex> Teenager.hey("Do you like math?")
+  iex> Bob.hey("Do you like math?")
   "Sure."
 
-  iex> Teenager.hey("HELLO!")
+  iex> Bob.hey("HELLO!")
   "Whoa, chill out!"
 
-  iex> Teenager.hey("Coding is cool.")
+  iex> Bob.hey("Coding is cool.")
   "Whatever."
   """
 
@@ -32,8 +32,8 @@ defmodule Teenager do
   defp letters?(input),  do: Regex.match?(~r/\p{L}+/, input)
 end
 
-# Another approach which abstracts knowing about string categories 
-# away from Teenager and into a single responsibility module.
+# Another approach which abstracts knowing about string categories
+# away from Bob and into a single responsibility module.
 # (This has been commented out to avoid raising a needless "redefinition"
 # warning)
 
@@ -43,10 +43,10 @@ end
 #   def question?(input), do: String.ends_with?(input, "?")
 #   defp letters?(input), do: Regex.match?(~r/\p{L}+/, input)
 # end
-# 
-# defmodule Teenager do
+#
+# defmodule Bob do
 #   import Message, only: [silent?: 1, shouting?: 1, question?: 1]
-# 
+#
 #   def hey(input) do
 #     cond do
 #       silent?(input)   -> "Fine. Be that way!"


### PR DESCRIPTION
Change the use of the word 'Teenager' to 'Bob' to bring content of
the .exs files more in line with the naming of the exercise.