### PR TITLE
Set ExUnit into trace mode

### DIFF
--- a/allergies/allergies_test.exs
+++ b/allergies/allergies_test.exs
@@ -6,7 +6,7 @@ end
 
 
 ExUnit.start
-ExUnit.configure exclude: :pending
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule AllergiesTest do
   use ExUnit.Case, async: true

--- a/anagram/anagram_test.exs
+++ b/anagram/anagram_test.exs
@@ -5,7 +5,7 @@ else
 end
 
 ExUnit.start
-ExUnit.configure exclude: :pending
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule AnagramTest do
   use ExUnit.Case

--- a/atbash-cipher/atbash_cipher_test.exs
+++ b/atbash-cipher/atbash_cipher_test.exs
@@ -5,7 +5,7 @@ else
 end
 
 ExUnit.start
-ExUnit.configure exclude: :pending
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule AtbashTest do
   use ExUnit.Case, async: true

--- a/bank-account/bank_account_test.exs
+++ b/bank-account/bank_account_test.exs
@@ -5,7 +5,7 @@ else
 end
 
 ExUnit.start
-ExUnit.configure exclude: :pending
+ExUnit.configure exclude: :pending, trace: true
 
 # The BankAccount module should support four calls:
 #

--- a/binary/binary_test.exs
+++ b/binary/binary_test.exs
@@ -5,7 +5,7 @@ else
 end
 
 ExUnit.start
-ExUnit.configure exclude: :pending
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule BinaryTest do
   use ExUnit.Case, async: true

--- a/bob/bob_test.exs
+++ b/bob/bob_test.exs
@@ -5,7 +5,7 @@ else
 end
 
 ExUnit.start
-ExUnit.configure(exclude: :pending)
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule TeenagerTest do
   use ExUnit.Case, async: true

--- a/custom-set/custom-set_test.exs
+++ b/custom-set/custom-set_test.exs
@@ -5,7 +5,7 @@ else
 end
 
 ExUnit.start
-ExUnit.configure exclude: :pending
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule CustomSetTest do
   use ExUnit.Case

--- a/difference-of-squares/difference_of_squares_test.exs
+++ b/difference-of-squares/difference_of_squares_test.exs
@@ -5,7 +5,7 @@ else
 end
 
 ExUnit.start
-ExUnit.configure exclude: :pending
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule DifferenceOfSquaresTest do
   use ExUnit.Case, async: true

--- a/dot-dsl/dot-dsl_test.exs
+++ b/dot-dsl/dot-dsl_test.exs
@@ -5,7 +5,7 @@ else
 end
 
 ExUnit.start
-ExUnit.configure exclude: :pending
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule DotTest do
   use ExUnit.Case, async: true

--- a/etl/etl_test.exs
+++ b/etl/etl_test.exs
@@ -5,7 +5,7 @@ else
 end
 
 ExUnit.start
-ExUnit.configure exclude: :pending
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule TransformTest do
   use ExUnit.Case, async: true

--- a/forth/forth_test.exs
+++ b/forth/forth_test.exs
@@ -5,7 +5,7 @@ else
 end
 
 ExUnit.start
-ExUnit.configure exclude: :pending
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule ForthTest do
   use ExUnit.Case

--- a/gigasecond/gigasecond_test.exs
+++ b/gigasecond/gigasecond_test.exs
@@ -5,7 +5,7 @@ else
 end
 
 ExUnit.start
-ExUnit.configure exclude: :pending
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule GigasecondTest do
   use ExUnit.Case

--- a/grade-school/grade_school_test.exs
+++ b/grade-school/grade_school_test.exs
@@ -5,7 +5,7 @@ else
 end
 
 ExUnit.start
-ExUnit.configure(exclude: :pending)
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule SchoolTest do
   use ExUnit.Case, async: true

--- a/grains/grains_test.exs
+++ b/grains/grains_test.exs
@@ -5,7 +5,7 @@ else
 end
 
 ExUnit.start
-ExUnit.configure exclude: :pending
+ExUnit.configure exclude: :pending, trace: true
 
 # NOTE: :math.pow/2 doesn't do what you'd expect:
 # `:math.pow(2, 64) == :math.pow(2, 64) - 1` is true.

--- a/largest-series-product/largest_series_product_test.exs
+++ b/largest-series-product/largest_series_product_test.exs
@@ -5,7 +5,7 @@ else
 end
 
 ExUnit.start
-ExUnit.configure exclude: :pending
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule LargestSeriesProductTest do
   use ExUnit.Case, async: false

--- a/leap/leap_test.exs
+++ b/leap/leap_test.exs
@@ -5,7 +5,7 @@ else
 end
 
 ExUnit.start
-ExUnit.configure exclude: :pending
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule LeapTest do
   use ExUnit.Case, async: true

--- a/list-ops/list_ops_test.exs
+++ b/list-ops/list_ops_test.exs
@@ -5,7 +5,7 @@ else
 end
 
 ExUnit.start
-ExUnit.configure exclude: :pending
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule ListOpsTest do
   alias ListOps, as: L

--- a/meetup/meetup_test.exs
+++ b/meetup/meetup_test.exs
@@ -5,7 +5,7 @@ else
 end
 
 ExUnit.start
-ExUnit.configure exclude: :pending
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule MeetupTest do
   use ExUnit.Case, async: false

--- a/minesweeper/minesweeper_test.exs
+++ b/minesweeper/minesweeper_test.exs
@@ -5,7 +5,7 @@ else
 end
 
 ExUnit.start
-ExUnit.configure exclude: :pending
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule MinesweeperTest do
   use ExUnit.Case, async: true

--- a/nth-prime/nth_prime_test.exs
+++ b/nth-prime/nth_prime_test.exs
@@ -5,7 +5,7 @@ else
 end
 
 ExUnit.start
-ExUnit.configure exclude: :pending
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule NthPrimeTest do
   use ExUnit.Case, async: true

--- a/nucleotide-count/nucleotide_count_test.exs
+++ b/nucleotide-count/nucleotide_count_test.exs
@@ -5,7 +5,7 @@ else
 end
 
 ExUnit.start
-ExUnit.configure exclude: :pending
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule DNATest do
   use ExUnit.Case, async: true

--- a/palindrome-products/palindrome_products_test.exs
+++ b/palindrome-products/palindrome_products_test.exs
@@ -5,7 +5,7 @@ else
 end
 
 ExUnit.start
-ExUnit.configure exclude: :pending
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule PalindromeProductsTest do
   use ExUnit.Case, async: true

--- a/parallel-letter-frequency/parallel_letter_frequency_test.exs
+++ b/parallel-letter-frequency/parallel_letter_frequency_test.exs
@@ -5,7 +5,7 @@ else
 end
 
 ExUnit.start
-ExUnit.configure exclude: :pending
+ExUnit.configure exclude: :pending, trace: true
 
 # Your code should contain a frequency(texts, workers) function which accepts a
 # list of texts and the number of workers to use in parallel.

--- a/phone-number/phone_number_test.exs
+++ b/phone-number/phone_number_test.exs
@@ -5,7 +5,7 @@ else
 end
 
 ExUnit.start
-ExUnit.configure(exclude: :pending)
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule PhoneTest do
   use ExUnit.Case, async: true

--- a/point-mutations/point_mutations_test.exs
+++ b/point-mutations/point_mutations_test.exs
@@ -5,7 +5,7 @@ else
 end
 
 ExUnit.start
-ExUnit.configure exclude: :pending
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule DNATest do
   use ExUnit.Case, async: true

--- a/prime-factors/prime_factors_test.exs
+++ b/prime-factors/prime_factors_test.exs
@@ -5,7 +5,7 @@ else
 end
 
 ExUnit.start
-ExUnit.configure exclude: :pending
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule PrimeFactorsTest do
   use ExUnit.Case, async: true

--- a/pythagorean-triplet/pythagorean_triplet_test.exs
+++ b/pythagorean-triplet/pythagorean_triplet_test.exs
@@ -5,7 +5,7 @@ else
 end
 
 ExUnit.start
-ExUnit.configure exclude: :pending
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule PythagoreanTripletTest do
   use ExUnit.Case, async: true

--- a/raindrops/raindrops_test.exs
+++ b/raindrops/raindrops_test.exs
@@ -5,7 +5,7 @@ else
 end
 
 ExUnit.start
-ExUnit.configure exclude: :pending
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule RaindropsTest do
   use ExUnit.Case, async: true

--- a/rna-transcription/rna_transcription_test.exs
+++ b/rna-transcription/rna_transcription_test.exs
@@ -5,7 +5,7 @@ else
 end
 
 ExUnit.start
-ExUnit.configure exclude: :pending
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule DNATest do
   use ExUnit.Case, async: true

--- a/roman-numerals/roman_numerals_test.exs
+++ b/roman-numerals/roman_numerals_test.exs
@@ -5,7 +5,7 @@ else
 end
 
 ExUnit.start
-ExUnit.configure exclude: :pending
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule RomanTest do
   use ExUnit.Case, async: true

--- a/scrabble-score/scrabble_score_test.exs
+++ b/scrabble-score/scrabble_score_test.exs
@@ -5,7 +5,7 @@ else
 end
 
 ExUnit.start
-ExUnit.configure exclude: :pending
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule ScrabbleScoreTest do
   use ExUnit.Case, async: true

--- a/sieve/sieve_test.exs
+++ b/sieve/sieve_test.exs
@@ -5,7 +5,7 @@ else
 end
 
 ExUnit.start
-ExUnit.configure exclude: :pending
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule SieveTest do
   use ExUnit.Case, async: true

--- a/space-age/space_age_test.exs
+++ b/space-age/space_age_test.exs
@@ -5,7 +5,7 @@ else
 end
 
 ExUnit.start
-ExUnit.configure exclude: :pending
+ExUnit.configure exclude: :pending, trace: true
 
 # You need to define a SpaceAge module containing a function age_on that given a
 # planet (:earth, :saturn, etc) and a number of seconds returns the age in years

--- a/sublist/sublist_test.exs
+++ b/sublist/sublist_test.exs
@@ -5,7 +5,7 @@ else
 end
 
 ExUnit.start
-ExUnit.configure(exclude: :pending)
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule SublistTest do
   use ExUnit.Case, async: true

--- a/sum-of-multiples/sum_of_multiples_test.exs
+++ b/sum-of-multiples/sum_of_multiples_test.exs
@@ -5,7 +5,7 @@ else
 end
 
 ExUnit.start
-ExUnit.configure exclude: :pending
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule SumOfMultiplesTest do
   use ExUnit.Case, async: true

--- a/triangle/triangle_test.exs
+++ b/triangle/triangle_test.exs
@@ -5,7 +5,7 @@ else
 end
 
 ExUnit.start
-ExUnit.configure exclude: :pending
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule TriangleTest do
   use ExUnit.Case, async: true

--- a/word-count/word_count_test.exs
+++ b/word-count/word_count_test.exs
@@ -5,7 +5,7 @@ else
 end
 
 ExUnit.start
-ExUnit.configure(exclude: :pending)
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule WordsTest do
   use ExUnit.Case

--- a/zipper/zipper_test.exs
+++ b/zipper/zipper_test.exs
@@ -5,7 +5,7 @@ else
 end
 
 ExUnit.start
-ExUnit.configure exclude: :pending
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule ZipperTest do
   alias BinTree, as: BT


### PR DESCRIPTION
In response to Issue#47.  Add 'trace: true' to Elixir tests,
providing a more verbose output that includes indicating what
tests are skipped.
