### PR TITLE
Add helpful information to the SETUP.md

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -1,7 +1,36 @@
 ## Running tests
 
+Execute the tests with:
+
 ```bash
 $ elixir bob_test.exs
 ```
 
 (Replace `bob_test.exs` with the name of the test file.)
+
+
+### Pending tests
+
+In the test suites, all but the first test have been skipped.
+
+Once you get a test passing, you can unskip the next one by
+commenting out the relevant `@tag :pending` with a `#` symbol.
+
+For example:
+
+```elixir
+# @tag :pending
+test "shouting" do
+  assert Teenager.hey("WATCH OUT!") == "Whoa, chill out!"
+end
+```
+
+Or, you can enable all the tests by commenting out the
+`ExUnit.configure` line in the test suite.
+
+```elixir
+# ExUnit.configure exclude: :pending, trace: true
+```
+
+For more detailed information about the Elixir track, please
+see the [help page](http://help.exercism.io/getting-started-with-elixir.html).


### PR DESCRIPTION
In response to Issue#37, add further information to SETUP.md
regarding running tests.  Specifically, more detail describing how
to deal with pending tests.  Also added in a link to the Exercism.io
Elixir help page.