### PR TITLE
Adds one more test to catch double counting multiples of both 3 and 5

### DIFF
--- a/sum-of-multiples/sum_of_multiples_test.exs
+++ b/sum-of-multiples/sum_of_multiples_test.exs
@@ -26,6 +26,11 @@ defmodule SumOfMultiplesTest do
   end
 
   @tag :pending
+  test "sum to 20" do
+    assert SumOfMultiples.to(20) == 78
+  end
+
+  @tag :pending
   test "sum to 1000" do
     assert SumOfMultiples.to(1000) == 233168
   end


### PR DESCRIPTION
This one tripped me up. Hopefully the test to 20 will make finding the double counting error a little more intuitive.