### PR TITLE
Normalize YAML in Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
+---
 language: elixir
-
 script:
-  - bin/fetch-configlet
-  - bin/configlet .
-  - mix deps.get
-  - EXERCISM_TEST_EXAMPLES=true mix test
+- bin/fetch-configlet
+- bin/configlet .
+- mix deps.get
+- EXERCISM_TEST_EXAMPLES=true mix test


### PR DESCRIPTION
The YAML was not quite valid. Travis can read it
and wasn't complaining, but this ensures that the YAML
is clean.