### PR TITLE
Rename outdated method name

### DIFF
--- a/nucleotide-count/dna.exs
+++ b/nucleotide-count/dna.exs
@@ -23,10 +23,10 @@ defmodule DNA do
 
   ## Examples
 
-  iex> DNA.nucleotide_counts('AATAA')
+  iex> DNA.histogram('AATAA')
   %{?A => 4, ?T => 1, ?C => 0, ?G => 0}
   """
-  @spec nucleotide_counts([char]) :: Dict.t
+  @spec histogram([char]) :: Dict.t
   def nucleotide_counts(strand) do
 
   end


### PR DESCRIPTION
The tests and `example.exs` reference the method as `histogram` but in the `dna.exs` it's still called `nucleotide_count`.