### PR TITLE
Include 'pending' specs in CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,5 @@ script:
 - bin/fetch-configlet
 - bin/configlet .
 - mix deps.get
-- EXERCISM_TEST_EXAMPLES=true mix test
+- EXERCISM_TEST_EXAMPLES=true mix test --include pending
 sudo: false


### PR DESCRIPTION
It seems that CI should run all tests against the example.exs files. Is that what other language tracks do? I assume the examples should always pass all tests which doesn't look like the case for us right now. 

//cc @kytrinyx @rubysolo 