### PR TITLE
Added missing test that made checking super lists necessary

### DIFF
--- a/sublist/sublist_test.exs
+++ b/sublist/sublist_test.exs
@@ -83,6 +83,11 @@ defmodule SublistTest do
   end
 
   @tag :pending
+  test "1 and 2 does not contain 3" do
+    assert Sublist.compare([1,2], [3]) == :unequal
+  end
+
+  @tag :pending
   test "partially matching superlist at start" do
     assert Sublist.compare([1,1,1,2], [1,1,2]) == :superlist
   end


### PR DESCRIPTION
I was able to complete all the tests without checking the values in a super list. All I needed to do was check the size.

I added a test case that makes it more explicit.