### PR TITLE
Replace map with keyword list

### DIFF
--- a/grade-school/example.exs
+++ b/grade-school/example.exs
@@ -1,16 +1,15 @@
 defmodule School do
-  def add(db, student, grade) do
-    Dict.update db, grade, [student], &([ student | &1 ])
+  def add(db, name, grade) do
+    Keyword.update(db, grade, [name], &[name|&1])
   end
 
   def grade(db, grade) do
-    Dict.get db, grade, []
+    Keyword.get(db, grade, [])
   end
 
   def sort(db) do
     db
-      |> Enum.map(fn({k, v}) -> {k, Enum.sort(v)} end)
-      |> Enum.sort
-      |> Enum.into(%{}) 
+    |> Enum.map(fn {k,v} -> {k, Enum.sort(v)} end)
+    |> Enum.sort
   end
 end

--- a/grade-school/grade_school_test.exs
+++ b/grade-school/grade_school_test.exs
@@ -10,65 +10,64 @@ ExUnit.configure exclude: :pending, trace: true
 defmodule SchoolTest do
   use ExUnit.Case
 
-  def db, do: %{}
+  def db, do: []
 
   test "add student" do
-    actual = School.add(db, "Aimee", 2)
-    assert actual == %{2 => ["Aimee"]}
+    actual = School.add(db, "Aimee", :grade_2)
+    assert actual == [grade_2: ["Aimee"]]
   end
 
   @tag :pending
   test "add more students in same class" do
     actual = db
-     |> School.add("James", 2)
-     |> School.add("Blair", 2)
-     |> School.add("Paul", 2)
+     |> School.add("James", :grade_2)
+     |> School.add("Blair", :grade_2)
+     |> School.add("Paul", :grade_2)
 
-    assert Enum.sort(actual[2]) == ["Blair", "James", "Paul"]
+    assert Enum.sort(actual[:grade_2]) == ["Blair", "James", "Paul"]
   end
 
   @tag :pending
   test "add students to different grades" do
     actual = db
-     |> School.add("Chelsea", 3)
-     |> School.add("Logan", 7)
+     |> School.add("Chelsea", :grade_3)
+     |> School.add("Logan", :grade_7)
 
-    assert actual == %{3 => ["Chelsea"], 7 => ["Logan"]}
+    assert actual == [grade_3: ["Chelsea"], grade_7: ["Logan"]]
   end
 
   @tag :pending
   test "get students in a grade" do
     actual = db
-     |> School.add("Bradley", 5)
-     |> School.add("Franklin", 5)
-     |> School.add("Jeff", 1)
-     |> School.grade(5)
+     |> School.add("Bradley", :grade_5)
+     |> School.add("Franklin", :grade_5)
+     |> School.add("Jeff", :grade_1)
+     |> School.grade(:grade_5)
 
     assert Enum.sort(actual) == ["Bradley", "Franklin"]
   end
 
   @tag :pending
-  test "get students in a non existant grade" do
-    assert [] == School.grade(db, 1)
+  test "get students in a non existent grade" do
+    assert [] == School.grade(db, :grade_1)
   end
 
   @tag :pending
   test "sort school by grade and by student name" do
     actual = db
-     |> School.add("Bart", 4)
-     |> School.add("Jennifer", 4)
-     |> School.add("Christopher", 4)
-     |> School.add("Kareem", 6)
-     |> School.add("Kyle", 3)
+     |> School.add("Bart", :grade_4)
+     |> School.add("Jennifer", :grade_4)
+     |> School.add("Christopher", :grade_4)
+     |> School.add("Kareem", :grade_6)
+     |> School.add("Kyle", :grade_3)
      |> School.sort
 
-    expected = %{
-     3 => ["Kyle"],
-     4 => ["Bart", "Christopher", "Jennifer"],
-     6 => ["Kareem"]
-    }
+    expected = [
+     grade_3: ["Kyle"],
+     grade_4: ["Bart", "Christopher", "Jennifer"],
+     grade_6: ["Kareem"]
+    ]
 
     assert expected == actual
   end
-
 end

--- a/grade-school/school.exs
+++ b/grade-school/school.exs
@@ -8,7 +8,7 @@ defmodule School do
   @doc """
   Add a student to a particular grade in school.
   """
-  @spec add(Dict.t, String.t, pos_integer) :: Dict.t
+  @spec add([{atom, any}], String.t, atom) :: [{atom, any}]
   def add(db, name, grade) do
 
   end
@@ -16,7 +16,7 @@ defmodule School do
   @doc """
   Return the names of the students in a particular grade.
   """
-  @spec grade(Dict.t, pos_integer) :: [String]
+  @spec grade([{atom, any}], atom) :: any
   def grade(db, grade) do
 
   end
@@ -24,7 +24,7 @@ defmodule School do
   @doc """
   Sorts the school by grade and name.
   """
-  @spec sort(Dict) :: Dict.t
+  @spec sort([{atom, any}]) :: [{atom, any}]
   def sort(db) do
 
   end


### PR DESCRIPTION
Maps are unsorted, but they currently have a strange quirk due to
an Erlang implementation detail which means that maps with less than
33 keys are actually sorted.
This means the "sort school by grade and by student name" test passes
when it shouldn't.
Unlike maps, keyword lists are ordered, as specified by the developer.

http://exercism.io/submissions/2a370c046f5449519e3c976fcaf58e68