### PR TITLE
dries up the code loading logic for each test file

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -32,5 +32,17 @@ Or, you can enable all the tests by commenting out the
 # ExUnit.configure exclude: :pending, trace: true
 ```
 
+
+
+## Run all tests
+```bash
+
+# with your implementation
+$ mix run test/test_helper.exs
+
+# with example implementation
+$ EXERCISM_TEST_EXAMPLES=true mix run test/test_helper.exs
+```
+
 For more detailed information about the Elixir track, please
 see the [help page](http://exercism.io/languages/elixir).

--- a/allergies/allergies_test.exs
+++ b/allergies/allergies_test.exs
@@ -1,12 +1,5 @@
-if System.get_env("EXERCISM_TEST_EXAMPLES") do
-  Code.load_file("example.exs")
-else
-  Code.load_file("allergies.exs")
-end
-
-
-ExUnit.start
-ExUnit.configure exclude: :pending, trace: true
+Code.load_file("../file_loader.ex", __DIR__)
+FileLoader.load("allergies", __DIR__)
 
 defmodule AllergiesTest do
   use ExUnit.Case, async: true

--- a/anagram/anagram_test.exs
+++ b/anagram/anagram_test.exs
@@ -1,11 +1,5 @@
-if System.get_env("EXERCISM_TEST_EXAMPLES") do
-  Code.load_file("example.exs")
-else
-  Code.load_file("anagram.exs")
-end
-
-ExUnit.start
-ExUnit.configure exclude: :pending, trace: true
+Code.load_file("../file_loader.ex", __DIR__)
+FileLoader.load("anagram", __DIR__)
 
 defmodule AnagramTest do
   use ExUnit.Case

--- a/atbash-cipher/atbash_cipher_test.exs
+++ b/atbash-cipher/atbash_cipher_test.exs
@@ -1,11 +1,5 @@
-if System.get_env("EXERCISM_TEST_EXAMPLES") do
-  Code.load_file("example.exs")
-else
-  Code.load_file("atbash.exs")
-end
-
-ExUnit.start
-ExUnit.configure exclude: :pending, trace: true
+Code.load_file("../file_loader.ex", __DIR__)
+FileLoader.load("atbash", __DIR__)
 
 defmodule AtbashTest do
   use ExUnit.Case, async: true

--- a/bank-account/bank_account_test.exs
+++ b/bank-account/bank_account_test.exs
@@ -1,11 +1,5 @@
-if System.get_env("EXERCISM_TEST_EXAMPLES") do
-  Code.load_file("example.exs")
-else
-  Code.load_file("account.exs")
-end
-
-ExUnit.start
-ExUnit.configure exclude: :pending, trace: true
+Code.load_file("../file_loader.ex", __DIR__)
+FileLoader.load("account", __DIR__)
 
 # The BankAccount module should support four calls:
 #

--- a/binary/binary_test.exs
+++ b/binary/binary_test.exs
@@ -1,11 +1,5 @@
-if System.get_env("EXERCISM_TEST_EXAMPLES") do
-  Code.load_file("example.exs")
-else
-  Code.load_file("binary.exs")
-end
-
-ExUnit.start
-ExUnit.configure exclude: :pending, trace: true
+Code.load_file("../file_loader.ex", __DIR__)
+FileLoader.load("binary", __DIR__)
 
 defmodule BinaryTest do
   use ExUnit.Case, async: true
@@ -49,12 +43,12 @@ defmodule BinaryTest do
   test "invalid binary is decimal 0" do
     assert Binary.to_decimal("carrot") == 0
   end
-  
+
   @tag :pending
   test "invalid binary is decimal 0 II" do
     assert Binary.to_decimal("convert01") == 0
   end
-  
+
   @tag :pending
   test "invalid binary is decimal 0 III" do
     assert Binary.to_decimal("10convert") == 0

--- a/bob/bob_test.exs
+++ b/bob/bob_test.exs
@@ -1,11 +1,5 @@
-if System.get_env("EXERCISM_TEST_EXAMPLES") do
-  Code.load_file("example.exs")
-else
-  Code.load_file("bob.exs")
-end
-
-ExUnit.start
-ExUnit.configure exclude: :pending, trace: true
+Code.load_file("../file_loader.ex", __DIR__)
+FileLoader.load("bob", __DIR__)
 
 defmodule BobTest do
   use ExUnit.Case, async: true

--- a/custom-set/custom-set_test.exs
+++ b/custom-set/custom-set_test.exs
@@ -1,11 +1,5 @@
-if System.get_env("EXERCISM_TEST_EXAMPLES") do
-  Code.load_file("example.exs")
-else
-  Code.load_file("custom_set.exs")
-end
-
-ExUnit.start
-ExUnit.configure exclude: :pending, trace: true
+Code.load_file("../file_loader.ex", __DIR__)
+FileLoader.load("custom_set", __DIR__)
 
 defmodule CustomSetTest do
   use ExUnit.Case

--- a/difference-of-squares/difference_of_squares_test.exs
+++ b/difference-of-squares/difference_of_squares_test.exs
@@ -1,11 +1,5 @@
-if System.get_env("EXERCISM_TEST_EXAMPLES") do
-  Code.load_file("example.exs")
-else
-  Code.load_file("difference_of_squares.exs")
-end
-
-ExUnit.start
-ExUnit.configure exclude: :pending, trace: true
+Code.load_file("../file_loader.ex", __DIR__)
+FileLoader.load("difference_of_squares", __DIR__)
 
 defmodule DifferenceOfSquaresTest do
   use ExUnit.Case, async: true

--- a/dot-dsl/dot-dsl_test.exs
+++ b/dot-dsl/dot-dsl_test.exs
@@ -1,11 +1,5 @@
-if System.get_env("EXERCISM_TEST_EXAMPLES") do
-  Code.load_file("example.exs")
-else
-  Code.load_file("dot.exs")
-end
-
-ExUnit.start
-ExUnit.configure exclude: :pending, trace: true
+Code.load_file("../file_loader.ex", __DIR__)
+FileLoader.load("dot", __DIR__)
 
 defmodule DotTest do
   use ExUnit.Case, async: true

--- a/etl/etl_test.exs
+++ b/etl/etl_test.exs
@@ -1,11 +1,5 @@
-if System.get_env("EXERCISM_TEST_EXAMPLES") do
-  Code.load_file("example.exs")
-else
-  Code.load_file("etl.exs")
-end
-
-ExUnit.start
-ExUnit.configure exclude: :pending, trace: true
+Code.load_file("../file_loader.ex", __DIR__)
+FileLoader.load("etl", __DIR__)
 
 defmodule TransformTest do
   use ExUnit.Case, async: true

--- a/file_loader.ex
+++ b/file_loader.ex
@@ -1,12 +1,14 @@
-defmodule FileLoader do
-  def load(name, dir) do
-    if System.get_env("EXERCISM_TEST_EXAMPLES") do
-      Code.load_file("example.exs", dir)
-    else
-      Code.load_file("#{name}.exs", dir)
-    end
+unless Code.ensure_loaded?(FileLoader) do
+  defmodule FileLoader do
+    def load(name, dir) do
+      if System.get_env("EXERCISM_TEST_EXAMPLES") do
+        Code.load_file("example.exs", dir)
+      else
+        Code.load_file("#{name}.exs", dir)
+      end
 
-    ExUnit.start
-    ExUnit.configure exclude: :pending, trace: true
+      ExUnit.start
+      ExUnit.configure exclude: :pending, trace: true
+    end
   end
 end

--- a/file_loader.ex
+++ b/file_loader.ex
@@ -1,0 +1,12 @@
+defmodule FileLoader do
+  def load(name, dir) do
+    if System.get_env("EXERCISM_TEST_EXAMPLES") do
+      Code.load_file("example.exs", dir)
+    else
+      Code.load_file("#{name}.exs", dir)
+    end
+
+    ExUnit.start
+    ExUnit.configure exclude: :pending, trace: true
+  end
+end

--- a/forth/forth_test.exs
+++ b/forth/forth_test.exs
@@ -1,11 +1,5 @@
-if System.get_env("EXERCISM_TEST_EXAMPLES") do
-  Code.load_file("example.exs")
-else
-  Code.load_file("forth.exs")
-end
-
-ExUnit.start
-ExUnit.configure exclude: :pending, trace: true
+Code.load_file("../file_loader.ex", __DIR__)
+FileLoader.load("forth", __DIR__)
 
 defmodule ForthTest do
   use ExUnit.Case

--- a/gigasecond/gigasecond_test.exs
+++ b/gigasecond/gigasecond_test.exs
@@ -1,11 +1,5 @@
-if System.get_env("EXERCISM_TEST_EXAMPLES") do
-  Code.load_file("example.exs")
-else
-  Code.load_file("gigasecond.exs")
-end
-
-ExUnit.start
-ExUnit.configure exclude: :pending, trace: true
+Code.load_file("../file_loader.ex", __DIR__)
+FileLoader.load("gigasecond", __DIR__)
 
 defmodule GigasecondTest do
   use ExUnit.Case

--- a/grade-school/grade_school_test.exs
+++ b/grade-school/grade_school_test.exs
@@ -1,11 +1,5 @@
-if System.get_env("EXERCISM_TEST_EXAMPLES") do
-  Code.load_file("example.exs")
-else
-  Code.load_file("school.exs")
-end
-
-ExUnit.start
-ExUnit.configure exclude: :pending, trace: true
+Code.load_file("../file_loader.ex", __DIR__)
+FileLoader.load("school", __DIR__)
 
 defmodule SchoolTest do
   use ExUnit.Case, async: true

--- a/grains/grains_test.exs
+++ b/grains/grains_test.exs
@@ -1,11 +1,5 @@
-if System.get_env("EXERCISM_TEST_EXAMPLES") do
-  Code.load_file("example.exs")
-else
-  Code.load_file("grains.exs")
-end
-
-ExUnit.start
-ExUnit.configure exclude: :pending, trace: true
+Code.load_file("../file_loader.ex", __DIR__)
+FileLoader.load("grains", __DIR__)
 
 # NOTE: :math.pow/2 doesn't do what you'd expect:
 # `:math.pow(2, 64) == :math.pow(2, 64) - 1` is true.

--- a/hello-world/hello_world_test.exs
+++ b/hello-world/hello_world_test.exs
@@ -1,11 +1,5 @@
-if System.get_env("EXERCISM_TEST_EXAMPLES") do
-  Code.load_file("example.exs")
-else
-  Code.load_file("hello_world.exs")
-end
-
-ExUnit.start
-ExUnit.configure exclude: :pending, trace: true
+Code.load_file("../file_loader.ex", __DIR__)
+FileLoader.load("hello_world", __DIR__)
 
 defmodule HelloWorldTest do
   use ExUnit.Case, async: true

--- a/largest-series-product/largest_series_product_test.exs
+++ b/largest-series-product/largest_series_product_test.exs
@@ -1,11 +1,5 @@
-if System.get_env("EXERCISM_TEST_EXAMPLES") do
-  Code.load_file("example.exs")
-else
-  Code.load_file("largest_series_product.exs")
-end
-
-ExUnit.start
-ExUnit.configure exclude: :pending, trace: true
+Code.load_file("../file_loader.ex", __DIR__)
+FileLoader.load("largest_series_product", __DIR__)
 
 defmodule LargestSeriesProductTest do
   use ExUnit.Case, async: false

--- a/leap/leap_test.exs
+++ b/leap/leap_test.exs
@@ -1,11 +1,5 @@
-if System.get_env("EXERCISM_TEST_EXAMPLES") do
-  Code.load_file("example.exs")
-else
-  Code.load_file("leap.exs")
-end
-
-ExUnit.start
-ExUnit.configure exclude: :pending, trace: true
+Code.load_file("../file_loader.ex", __DIR__)
+FileLoader.load("leap", __DIR__)
 
 defmodule LeapTest do
   use ExUnit.Case, async: true

--- a/list-ops/list_ops_test.exs
+++ b/list-ops/list_ops_test.exs
@@ -1,11 +1,5 @@
-if System.get_env("EXERCISM_TEST_EXAMPLES") do
-  Code.load_file("example.exs")
-else
-  Code.load_file("list_ops.exs")
-end
-
-ExUnit.start
-ExUnit.configure exclude: :pending, trace: true
+Code.load_file("../file_loader.ex", __DIR__)
+FileLoader.load("list_ops", __DIR__)
 
 defmodule ListOpsTest do
   alias ListOps, as: L

--- a/meetup/meetup_test.exs
+++ b/meetup/meetup_test.exs
@@ -1,11 +1,5 @@
-if System.get_env("EXERCISM_TEST_EXAMPLES") do
-  Code.load_file("example.exs")
-else
-  Code.load_file("meetup.exs")
-end
-
-ExUnit.start
-ExUnit.configure exclude: :pending, trace: true
+Code.load_file("../file_loader.ex", __DIR__)
+FileLoader.load("meetup", __DIR__)
 
 defmodule MeetupTest do
   use ExUnit.Case, async: false

--- a/minesweeper/minesweeper_test.exs
+++ b/minesweeper/minesweeper_test.exs
@@ -1,11 +1,5 @@
-if System.get_env("EXERCISM_TEST_EXAMPLES") do
-  Code.load_file("example.exs")
-else
-  Code.load_file("minesweeper.exs")
-end
-
-ExUnit.start
-ExUnit.configure exclude: :pending, trace: true
+Code.load_file("../file_loader.ex", __DIR__)
+FileLoader.load("minesweeper", __DIR__)
 
 defmodule MinesweeperTest do
   use ExUnit.Case, async: true

--- a/nth-prime/nth_prime_test.exs
+++ b/nth-prime/nth_prime_test.exs
@@ -1,11 +1,5 @@
-if System.get_env("EXERCISM_TEST_EXAMPLES") do
-  Code.load_file("example.exs")
-else
-  Code.load_file("nth_prime.exs")
-end
-
-ExUnit.start
-ExUnit.configure exclude: :pending, trace: true
+Code.load_file("../file_loader.ex", __DIR__)
+FileLoader.load("nth_prime", __DIR__)
 
 defmodule NthPrimeTest do
   use ExUnit.Case, async: true

--- a/nucleotide-count/nucleotide_count_test.exs
+++ b/nucleotide-count/nucleotide_count_test.exs
@@ -1,11 +1,5 @@
-if System.get_env("EXERCISM_TEST_EXAMPLES") do
-  Code.load_file("example.exs")
-else
-  Code.load_file("dna.exs")
-end
-
-ExUnit.start
-ExUnit.configure exclude: :pending, trace: true
+Code.load_file("../file_loader.ex", __DIR__)
+FileLoader.load("dna", __DIR__)
 
 defmodule DNATest do
   use ExUnit.Case, async: true
@@ -14,12 +8,12 @@ defmodule DNATest do
   test "empty dna string has no adenosine" do
     assert DNA.count('', ?A) == 0
   end
-  
+
   @tag :pending
   test "repetitive cytidine gets counted" do
     assert DNA.count('CCCCC', ?C) == 5
   end
-  
+
   @tag :pending
   test "counts only thymidine" do
     assert DNA.count('GGGGGTAACCCGG', ?T) == 1
@@ -50,14 +44,14 @@ defmodule DNATest do
       DNA.histogram('JOHNNYAPPLESEED')
     end
   end
-    
+
   @tag :pending
   test "count validates the nucleotide" do
     assert_raise ArgumentError, fn ->
       DNA.count('', ?U)
     end
   end
-  
+
   @tag :pending
   test "count validates the strand" do
     assert_raise ArgumentError, fn ->

--- a/palindrome-products/palindrome_products_test.exs
+++ b/palindrome-products/palindrome_products_test.exs
@@ -1,11 +1,5 @@
-if System.get_env("EXERCISM_TEST_EXAMPLES") do
-  Code.load_file("example.exs")
-else
-  Code.load_file("palindrome_products.exs")
-end
-
-ExUnit.start
-ExUnit.configure exclude: :pending, trace: true
+Code.load_file("../file_loader.ex", __DIR__)
+FileLoader.load("palindrome_products", __DIR__)
 
 defmodule PalindromeProductsTest do
   use ExUnit.Case, async: true

--- a/parallel-letter-frequency/parallel_letter_frequency_test.exs
+++ b/parallel-letter-frequency/parallel_letter_frequency_test.exs
@@ -1,11 +1,5 @@
-if System.get_env("EXERCISM_TEST_EXAMPLES") do
-  Code.load_file("example.exs")
-else
-  Code.load_file("frequency.exs")
-end
-
-ExUnit.start
-ExUnit.configure exclude: :pending, trace: true
+Code.load_file("../file_loader.ex", __DIR__)
+FileLoader.load("frequency", __DIR__)
 
 # Your code should contain a frequency(texts, workers) function which accepts a
 # list of texts and the number of workers to use in parallel.

--- a/phone-number/phone_number_test.exs
+++ b/phone-number/phone_number_test.exs
@@ -1,11 +1,5 @@
-if System.get_env("EXERCISM_TEST_EXAMPLES") do
-  Code.load_file("example.exs")
-else
-  Code.load_file("phone_number.exs")
-end
-
-ExUnit.start
-ExUnit.configure exclude: :pending, trace: true
+Code.load_file("../file_loader.ex", __DIR__)
+FileLoader.load("phone_number", __DIR__)
 
 defmodule PhoneTest do
   use ExUnit.Case, async: true

--- a/point-mutations/point_mutations_test.exs
+++ b/point-mutations/point_mutations_test.exs
@@ -1,11 +1,5 @@
-if System.get_env("EXERCISM_TEST_EXAMPLES") do
-  Code.load_file("example.exs")
-else
-  Code.load_file("point_mutations.exs")
-end
-
-ExUnit.start
-ExUnit.configure exclude: :pending, trace: true
+Code.load_file("../file_loader.ex", __DIR__)
+FileLoader.load("point_mutations", __DIR__)
 
 defmodule DNATest do
   use ExUnit.Case, async: true

--- a/prime-factors/prime_factors_test.exs
+++ b/prime-factors/prime_factors_test.exs
@@ -1,11 +1,5 @@
-if System.get_env("EXERCISM_TEST_EXAMPLES") do
-  Code.load_file("example.exs")
-else
-  Code.load_file("prime_factors.exs")
-end
-
-ExUnit.start
-ExUnit.configure exclude: :pending, trace: true
+Code.load_file("../file_loader.ex", __DIR__)
+FileLoader.load("prime_factors", __DIR__)
 
 defmodule PrimeFactorsTest do
   use ExUnit.Case, async: true

--- a/pythagorean-triplet/pythagorean_triplet_test.exs
+++ b/pythagorean-triplet/pythagorean_triplet_test.exs
@@ -1,11 +1,5 @@
-if System.get_env("EXERCISM_TEST_EXAMPLES") do
-  Code.load_file("example.exs")
-else
-  Code.load_file("pythagorean_triplet.exs")
-end
-
-ExUnit.start
-ExUnit.configure exclude: :pending, trace: true
+Code.load_file("../file_loader.ex", __DIR__)
+FileLoader.load("pythagorean_triplet", __DIR__)
 
 defmodule PythagoreanTripletTest do
   use ExUnit.Case, async: true

--- a/raindrops/raindrops_test.exs
+++ b/raindrops/raindrops_test.exs
@@ -1,11 +1,5 @@
-if System.get_env("EXERCISM_TEST_EXAMPLES") do
-  Code.load_file("example.exs")
-else
-  Code.load_file("raindrops.exs")
-end
-
-ExUnit.start
-ExUnit.configure exclude: :pending, trace: true
+Code.load_file("../file_loader.ex", __DIR__)
+FileLoader.load("raindrops", __DIR__)
 
 defmodule RaindropsTest do
   use ExUnit.Case, async: true

--- a/rna-transcription/rna_transcription_test.exs
+++ b/rna-transcription/rna_transcription_test.exs
@@ -1,11 +1,5 @@
-if System.get_env("EXERCISM_TEST_EXAMPLES") do
-  Code.load_file("example.exs")
-else
-  Code.load_file("dna.exs")
-end
-
-ExUnit.start
-ExUnit.configure exclude: :pending, trace: true
+Code.load_file("../file_loader.ex", __DIR__)
+FileLoader.load("dna", __DIR__)
 
 defmodule DNATest do
   use ExUnit.Case, async: true

--- a/roman-numerals/roman_numerals_test.exs
+++ b/roman-numerals/roman_numerals_test.exs
@@ -1,11 +1,5 @@
-if System.get_env("EXERCISM_TEST_EXAMPLES") do
-  Code.load_file("example.exs")
-else
-  Code.load_file("roman.exs")
-end
-
-ExUnit.start
-ExUnit.configure exclude: :pending, trace: true
+Code.load_file("../file_loader.ex", __DIR__)
+FileLoader.load("roman", __DIR__)
 
 defmodule RomanTest do
   use ExUnit.Case, async: true

--- a/scrabble-score/scrabble_score_test.exs
+++ b/scrabble-score/scrabble_score_test.exs
@@ -1,11 +1,5 @@
-if System.get_env("EXERCISM_TEST_EXAMPLES") do
-  Code.load_file("example.exs")
-else
-  Code.load_file("scrabble.exs")
-end
-
-ExUnit.start
-ExUnit.configure exclude: :pending, trace: true
+Code.load_file("../file_loader.ex", __DIR__)
+FileLoader.load("scrabble", __DIR__)
 
 defmodule ScrabbleScoreTest do
   use ExUnit.Case, async: true

--- a/sieve/sieve_test.exs
+++ b/sieve/sieve_test.exs
@@ -1,11 +1,5 @@
-if System.get_env("EXERCISM_TEST_EXAMPLES") do
-  Code.load_file("example.exs")
-else
-  Code.load_file("sieve.exs")
-end
-
-ExUnit.start
-ExUnit.configure exclude: :pending, trace: true
+Code.load_file("../file_loader.ex", __DIR__)
+FileLoader.load("sieve", __DIR__)
 
 defmodule SieveTest do
   use ExUnit.Case, async: true

--- a/space-age/space_age_test.exs
+++ b/space-age/space_age_test.exs
@@ -1,11 +1,5 @@
-if System.get_env("EXERCISM_TEST_EXAMPLES") do
-  Code.load_file("example.exs")
-else
-  Code.load_file("space_age.exs")
-end
-
-ExUnit.start
-ExUnit.configure exclude: :pending, trace: true
+Code.load_file("../file_loader.ex", __DIR__)
+FileLoader.load("space_age", __DIR__)
 
 # You need to define a SpaceAge module containing a function age_on that given a
 # planet (:earth, :saturn, etc) and a number of seconds returns the age in years

--- a/sublist/sublist_test.exs
+++ b/sublist/sublist_test.exs
@@ -1,11 +1,5 @@
-if System.get_env("EXERCISM_TEST_EXAMPLES") do
-  Code.load_file("example.exs")
-else
-  Code.load_file("sublist.exs")
-end
-
-ExUnit.start
-ExUnit.configure exclude: :pending, trace: true
+Code.load_file("../file_loader.ex", __DIR__)
+FileLoader.load("sublist", __DIR__)
 
 defmodule SublistTest do
   use ExUnit.Case, async: true

--- a/sum-of-multiples/sum_of_multiples_test.exs
+++ b/sum-of-multiples/sum_of_multiples_test.exs
@@ -1,11 +1,5 @@
-if System.get_env("EXERCISM_TEST_EXAMPLES") do
-  Code.load_file("example.exs")
-else
-  Code.load_file("sum_of_multiples.exs")
-end
-
-ExUnit.start
-ExUnit.configure exclude: :pending, trace: true
+Code.load_file("../file_loader.ex", __DIR__)
+FileLoader.load("sum_of_multiples", __DIR__)
 
 defmodule SumOfMultiplesTest do
   use ExUnit.Case, async: true

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,12 +1,6 @@
-
-project_root = File.cwd!
-active_problems = "config.json" |> File.read! |> Poison.decode! |> Dict.get "problems"
+active_problems = "config.json" |> File.read! |> Poison.decode! |> Dict.get("problems")
 
 Enum.each active_problems, fn dir ->
-    File.cd! dir
-    IO.puts "loading tests for " <> dir
-    "*test.ex*" |> Path.wildcard |> List.first |> Code.require_file
-    File.cd! project_root
+  IO.puts "********* loading tests for " <> dir  <> " ************* "
+  "#{dir}/*_test.ex*" |> Path.wildcard |> List.first |> Code.require_file
 end
-
-ExUnit.start()

--- a/triangle/triangle_test.exs
+++ b/triangle/triangle_test.exs
@@ -1,11 +1,5 @@
-if System.get_env("EXERCISM_TEST_EXAMPLES") do
-  Code.load_file("example.exs")
-else
-  Code.load_file("triangle.exs")
-end
-
-ExUnit.start
-ExUnit.configure exclude: :pending, trace: true
+Code.load_file("../file_loader.ex", __DIR__)
+FileLoader.load("triangle", __DIR__)
 
 defmodule TriangleTest do
   use ExUnit.Case, async: true

--- a/word-count/word_count_test.exs
+++ b/word-count/word_count_test.exs
@@ -1,11 +1,5 @@
-if System.get_env("EXERCISM_TEST_EXAMPLES") do
-  Code.load_file("example.exs")
-else
-  Code.load_file("word_count.exs")
-end
-
-ExUnit.start
-ExUnit.configure exclude: :pending, trace: true
+Code.load_file("../file_loader.ex", __DIR__)
+FileLoader.load("word_count", __DIR__)
 
 defmodule WordsTest do
   use ExUnit.Case

--- a/zipper/zipper_test.exs
+++ b/zipper/zipper_test.exs
@@ -1,11 +1,5 @@
-if System.get_env("EXERCISM_TEST_EXAMPLES") do
-  Code.load_file("example.exs")
-else
-  Code.load_file("zipper.exs")
-end
-
-ExUnit.start
-ExUnit.configure exclude: :pending, trace: true
+Code.load_file("../file_loader.ex", __DIR__)
+FileLoader.load("zipper", __DIR__)
 
 defmodule ZipperTest do
   alias BinTree, as: BT


### PR DESCRIPTION
problem: 
- each test file has some boilerplate code for loading either example or the users implementation  + starting ExUnit
- running all tests with test/test_helper via `mix test` did not work


solution: 
- provide a file_loader, that has the logic bits which file to load
- it is also starting the ExUnit and centralizes the configuration for it
- update the test/test_helper to do a bit less
- update SETUP.md with instructions how to run test for all examples 


Gotchas: 
- you will see warnings due to redefined FileLoader module: 
`file_loader.ex:1: warning: redefining module FileLoader`