### PR TITLE
Fix broken link

### DIFF
--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -1,6 +1,6 @@
 Exercism provides exercises and feedback but can be difficult to jump into for those learning Elixir for the first time. These resources can help you get started:
 
-* [Elixir Getting Started Guide](http://elixir-lang.org/getting_started/1.html)
+* [Elixir Getting Started Guide](http://elixir-lang.org/getting-started/introduction.html)
 * [Elixir Documentation](http://elixir-lang.org/docs/stable/elixir/)
 * [Programming Elixir](http://pragprog.com/book/elixir/programming-elixir), by Dave Thomas
 * [StackOverflow](http://stackoverflow.com/questions/tagged/elixir)


### PR DESCRIPTION
Current link for Getting Started appears to be broken. This is probably the current equivalent: http://elixir-lang.org/getting-started/introduction.html