### PR TITLE
Remove `async: true` from tests as it is redundant.

### DIFF
--- a/allergies/allergies_test.exs
+++ b/allergies/allergies_test.exs
@@ -9,7 +9,7 @@ ExUnit.start
 ExUnit.configure exclude: :pending, trace: true
 
 defmodule AllergiesTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
 
   # @tag :pending
   test "no_allergies_at_all" do

--- a/atbash-cipher/atbash_cipher_test.exs
+++ b/atbash-cipher/atbash_cipher_test.exs
@@ -8,7 +8,7 @@ ExUnit.start
 ExUnit.configure exclude: :pending, trace: true
 
 defmodule AtbashTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
 
   # @tag :pending
   test "encode no" do

--- a/bank-account/bank_account_test.exs
+++ b/bank-account/bank_account_test.exs
@@ -25,7 +25,7 @@ ExUnit.configure exclude: :pending, trace: true
 # The initial value of the bank account should be 0.
 
 defmodule BankAccountTest do
-  use ExUnit.Case, async: false # Tests should not overlap in execution.
+  use ExUnit.Case
 
   setup do
     account = BankAccount.open_bank()

--- a/binary/binary_test.exs
+++ b/binary/binary_test.exs
@@ -8,7 +8,7 @@ ExUnit.start
 ExUnit.configure exclude: :pending, trace: true
 
 defmodule BinaryTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
 
   # @tag :pending
   test "binary 1 is decimal 1" do

--- a/bob/bob_test.exs
+++ b/bob/bob_test.exs
@@ -8,7 +8,7 @@ ExUnit.start
 ExUnit.configure exclude: :pending, trace: true
 
 defmodule BobTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
 
   test "stating something" do
     assert Bob.hey("Tom-ay-to, tom-aaaah-to.") == "Whatever."

--- a/difference-of-squares/difference_of_squares_test.exs
+++ b/difference-of-squares/difference_of_squares_test.exs
@@ -8,7 +8,7 @@ ExUnit.start
 ExUnit.configure exclude: :pending, trace: true
 
 defmodule DifferenceOfSquaresTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
 
   # @tag :pending
   test "square of sums to 5" do

--- a/dot-dsl/dot-dsl_test.exs
+++ b/dot-dsl/dot-dsl_test.exs
@@ -8,7 +8,7 @@ ExUnit.start
 ExUnit.configure exclude: :pending, trace: true
 
 defmodule DotTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
   require Dot
 
   # Expand at RunTime, used to avoid invalid macro calls preventing compilation

--- a/etl/etl_test.exs
+++ b/etl/etl_test.exs
@@ -8,7 +8,7 @@ ExUnit.start
 ExUnit.configure exclude: :pending, trace: true
 
 defmodule TransformTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
 
   # @tag :pending
   test "transform one value" do

--- a/grade-school/grade_school_test.exs
+++ b/grade-school/grade_school_test.exs
@@ -8,7 +8,7 @@ ExUnit.start
 ExUnit.configure exclude: :pending, trace: true
 
 defmodule SchoolTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
 
   def db, do: %{}
 

--- a/hello-world/hello_world_test.exs
+++ b/hello-world/hello_world_test.exs
@@ -8,7 +8,7 @@ ExUnit.start
 ExUnit.configure exclude: :pending, trace: true
 
 defmodule HelloWorldTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
 
   test "says hello with no name" do
     assert HelloWorld.hello() == "Hello, World!"

--- a/largest-series-product/largest_series_product_test.exs
+++ b/largest-series-product/largest_series_product_test.exs
@@ -8,7 +8,7 @@ ExUnit.start
 ExUnit.configure exclude: :pending, trace: true
 
 defmodule LargestSeriesProductTest do
-  use ExUnit.Case, async: false
+  use ExUnit.Case
 
   # @tag :pending
   test "digits" do

--- a/leap/leap_test.exs
+++ b/leap/leap_test.exs
@@ -8,7 +8,7 @@ ExUnit.start
 ExUnit.configure exclude: :pending, trace: true
 
 defmodule LeapTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
 
   # @tag :pending
   test "vanilla leap year" do

--- a/list-ops/list_ops_test.exs
+++ b/list-ops/list_ops_test.exs
@@ -10,7 +10,7 @@ ExUnit.configure exclude: :pending, trace: true
 defmodule ListOpsTest do
   alias ListOps, as: L
 
-  use ExUnit.Case, async: true
+  use ExUnit.Case
 
   defp odd?(n), do: rem(n, 2) == 1
 

--- a/meetup/meetup_test.exs
+++ b/meetup/meetup_test.exs
@@ -8,7 +8,7 @@ ExUnit.start
 ExUnit.configure exclude: :pending, trace: true
 
 defmodule MeetupTest do
-  use ExUnit.Case, async: false
+  use ExUnit.Case
 
   # @tag :pending
   test "monteenth of may 2013" do

--- a/minesweeper/minesweeper_test.exs
+++ b/minesweeper/minesweeper_test.exs
@@ -8,7 +8,7 @@ ExUnit.start
 ExUnit.configure exclude: :pending, trace: true
 
 defmodule MinesweeperTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
 
   defp clean(b), do: Enum.map(b, &String.replace(&1, ~r/[^*]/, " "))
 

--- a/nth-prime/nth_prime_test.exs
+++ b/nth-prime/nth_prime_test.exs
@@ -8,7 +8,7 @@ ExUnit.start
 ExUnit.configure exclude: :pending, trace: true
 
 defmodule NthPrimeTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
 
   # @tag :pending
   test "first prime" do

--- a/nucleotide-count/nucleotide_count_test.exs
+++ b/nucleotide-count/nucleotide_count_test.exs
@@ -8,7 +8,7 @@ ExUnit.start
 ExUnit.configure exclude: :pending, trace: true
 
 defmodule DNATest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
 
   # @tag :pending
   test "empty dna string has no adenosine" do

--- a/palindrome-products/palindrome_products_test.exs
+++ b/palindrome-products/palindrome_products_test.exs
@@ -8,7 +8,7 @@ ExUnit.start
 ExUnit.configure exclude: :pending, trace: true
 
 defmodule PalindromeProductsTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
 
   # @tag :pending
   test "largest palindrome from single digit factors" do

--- a/parallel-letter-frequency/parallel_letter_frequency_test.exs
+++ b/parallel-letter-frequency/parallel_letter_frequency_test.exs
@@ -11,7 +11,7 @@ ExUnit.configure exclude: :pending, trace: true
 # list of texts and the number of workers to use in parallel.
 
 defmodule FrequencyTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
 
   # Poem by Friedrich Schiller. The corresponding music is the European Anthem.
   @ode_an_die_freude """

--- a/phone-number/phone_number_test.exs
+++ b/phone-number/phone_number_test.exs
@@ -8,7 +8,7 @@ ExUnit.start
 ExUnit.configure exclude: :pending, trace: true
 
 defmodule PhoneTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
 
   test "cleans number" do
     assert Phone.number("(123) 456-7890") == "1234567890"

--- a/point-mutations/point_mutations_test.exs
+++ b/point-mutations/point_mutations_test.exs
@@ -8,7 +8,7 @@ ExUnit.start
 ExUnit.configure exclude: :pending, trace: true
 
 defmodule DNATest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
 
   # @tag :pending
   test "no difference between empty strands" do

--- a/prime-factors/prime_factors_test.exs
+++ b/prime-factors/prime_factors_test.exs
@@ -8,7 +8,7 @@ ExUnit.start
 ExUnit.configure exclude: :pending, trace: true
 
 defmodule PrimeFactorsTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
 
   # @tag :pending
   test "1" do

--- a/pythagorean-triplet/pythagorean_triplet_test.exs
+++ b/pythagorean-triplet/pythagorean_triplet_test.exs
@@ -8,7 +8,7 @@ ExUnit.start
 ExUnit.configure exclude: :pending, trace: true
 
 defmodule PythagoreanTripletTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
 
   # @tag :pending
   test "sum" do

--- a/raindrops/raindrops_test.exs
+++ b/raindrops/raindrops_test.exs
@@ -8,7 +8,7 @@ ExUnit.start
 ExUnit.configure exclude: :pending, trace: true
 
 defmodule RaindropsTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
 
   # @tag :pending
   test "1" do

--- a/rna-transcription/rna_transcription_test.exs
+++ b/rna-transcription/rna_transcription_test.exs
@@ -8,7 +8,7 @@ ExUnit.start
 ExUnit.configure exclude: :pending, trace: true
 
 defmodule DNATest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
 
   # @tag :pending
   test "transcribes guanine to cytosine" do

--- a/roman-numerals/roman_numerals_test.exs
+++ b/roman-numerals/roman_numerals_test.exs
@@ -8,7 +8,7 @@ ExUnit.start
 ExUnit.configure exclude: :pending, trace: true
 
 defmodule RomanTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
 
   # @tag :pending
   test "1" do

--- a/scrabble-score/scrabble_score_test.exs
+++ b/scrabble-score/scrabble_score_test.exs
@@ -8,7 +8,7 @@ ExUnit.start
 ExUnit.configure exclude: :pending, trace: true
 
 defmodule ScrabbleScoreTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
 
   # @tag :pending
   test "empty word scores zero" do

--- a/sieve/sieve_test.exs
+++ b/sieve/sieve_test.exs
@@ -8,7 +8,7 @@ ExUnit.start
 ExUnit.configure exclude: :pending, trace: true
 
 defmodule SieveTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
 
   # @tag :pending
   test "a few primes" do

--- a/space-age/space_age_test.exs
+++ b/space-age/space_age_test.exs
@@ -12,7 +12,7 @@ ExUnit.configure exclude: :pending, trace: true
 # on that planet as a floating point number.
 
 defmodule SpageAgeTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
 
   # @tag :pending
   test "age on Earth" do

--- a/sublist/sublist_test.exs
+++ b/sublist/sublist_test.exs
@@ -8,7 +8,7 @@ ExUnit.start
 ExUnit.configure exclude: :pending, trace: true
 
 defmodule SublistTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
 
   test "empty equals empty" do
     assert Sublist.compare([], []) == :equal

--- a/sum-of-multiples/sum_of_multiples_test.exs
+++ b/sum-of-multiples/sum_of_multiples_test.exs
@@ -8,7 +8,7 @@ ExUnit.start
 ExUnit.configure exclude: :pending, trace: true
 
 defmodule SumOfMultiplesTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
 
   # @tag :pending
   test "sum to 1" do

--- a/triangle/triangle_test.exs
+++ b/triangle/triangle_test.exs
@@ -8,7 +8,7 @@ ExUnit.start
 ExUnit.configure exclude: :pending, trace: true
 
 defmodule TriangleTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
 
   # @tag :pending
   test "equilateral triangles have equal sides" do

--- a/zipper/zipper_test.exs
+++ b/zipper/zipper_test.exs
@@ -26,7 +26,7 @@ defmodule ZipperTest do
     end
   end
 
-  use ExUnit.Case, async: false
+  use ExUnit.Case
 
   defp bt(value, left, right), do: %BT{value: value, left: left, right: right}
   defp leaf(value), do: %BT{value: value}


### PR DESCRIPTION
When trace is set to true, as it is in all tests to
show more detailed information, tests are run
synchronously, therefore `async: true` has no effect.
`async: false` is the default.