### PR TITLE
Adds the acronym exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -7,6 +7,7 @@
     "hello-world",
     "bob",
     "word-count",
+    "acronym",
     "list-ops",
     "sublist",
     "anagram",

--- a/exercises/acronym/acronym.exs
+++ b/exercises/acronym/acronym.exs
@@ -3,6 +3,7 @@ defmodule Acronym do
   Generate an acronym from a string. 
   "This is a string" => "TIAS"
   """
+  @spec abbreviate(string) :: String.t()
   def abbreviate(string) do
    
   end

--- a/exercises/acronym/acronym.exs
+++ b/exercises/acronym/acronym.exs
@@ -1,0 +1,9 @@
+defmodule Acronym do
+  @doc """
+  Generate an acronym from a string. 
+  "This is a string" => "TIAS"
+  """
+  def abbreviate(string) do
+   
+  end
+end

--- a/exercises/acronym/acronym_test.exs
+++ b/exercises/acronym/acronym_test.exs
@@ -1,0 +1,36 @@
+if System.get_env("EXERCISM_TEST_EXAMPLES") do
+  Code.load_file("example.exs")
+else
+  Code.load_file("acronym.exs")
+end
+
+ExUnit.start
+ExUnit.configure exclude: :pending, trace: true
+
+defmodule AnagramTest do
+  use ExUnit.Case
+
+  test "it produces acronyms from title case" do
+    assert Acronym.abbreviate("Portable Networks Graphic") === "PNG"
+  end
+
+  @tag :pending
+  test "it produces acronyms from lower case" do
+    assert Acronym.abbreviate("Ruby on Rails") === "ROR"
+  end
+
+  @tag :pending
+  test "it produces acronyms from inconsistent case" do
+    assert Acronym.abbreviate("HyperText Markup Language") === "HTML"
+  end
+
+  @tag :pending
+  test "it ignores punctuation" do
+    assert Acronym.abbreviate("First in, First out") === "FIFO"
+  end
+
+  @tag :pending
+  test "produces acronyms ignoring punctuation and casing" do
+    assert Acronym.abbreviate("Complementary Metal-Oxide semiconductor") === "CMOS"
+  end
+end

--- a/exercises/acronym/example.exs
+++ b/exercises/acronym/example.exs
@@ -1,0 +1,10 @@
+defmodule Acronym do
+
+  def abbreviate(string) do
+    Regex.scan(~r/[A-Z]+[a-z]*|[a-z]+/, string)
+    |> List.flatten
+    |> Enum.map(fn(x) -> String.first(x) end)
+    |> Enum.join("")
+    |> String.upcase
+  end
+end

--- a/exercises/acronym/example.exs
+++ b/exercises/acronym/example.exs
@@ -1,5 +1,6 @@
 defmodule Acronym do
-
+  
+  @spec abbreviate(string) :: String.t()
   def abbreviate(string) do
     Regex.scan(~r/[A-Z]+[a-z]*|[a-z]+/, string)
     |> List.flatten


### PR DESCRIPTION
Ports the acronym exercise into `elixir`. 

- [x] `x-common` already contains the metadata
- [x] Updated `config.json`
- [x] Specs :palm_tree: 