### PR TITLE
Adds the run-length-encoding exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -8,6 +8,7 @@
     "bob",
     "word-count",
     "acronym",
+    "run-length-encoding",
     "list-ops",
     "sublist",
     "anagram",

--- a/exercises/run-length-encoding/example.exs
+++ b/exercises/run-length-encoding/example.exs
@@ -1,0 +1,15 @@
+defmodule RunLengthEncoder do 
+
+  @spec encode(string) :: String.t
+  def encode(string) do
+    Regex.scan(~r/([A-Z])\1*/, string)
+    |> Enum.map(fn([run, c]) -> "#{String.length(run)}#{c}" end)
+    |> Enum.join
+  end
+
+  @spec decode(string) :: String.t
+  def decode(string) do
+    Regex.scan(~r/(\d+)(.)/, string)
+    |> Enum.map_join(fn [_,n,c] -> String.duplicate(c, String.to_integer(n)) end)
+  end
+end

--- a/exercises/run-length-encoding/example.exs
+++ b/exercises/run-length-encoding/example.exs
@@ -3,8 +3,7 @@ defmodule RunLengthEncoder do
   @spec encode(string) :: String.t
   def encode(string) do
     Regex.scan(~r/([A-Z])\1*/, string)
-    |> Enum.map(fn([run, c]) -> "#{String.length(run)}#{c}" end)
-    |> Enum.join
+    |> Enum.map_join(fn([run, c]) -> "#{String.length(run)}#{c}" end)
   end
 
   @spec decode(string) :: String.t

--- a/exercises/run-length-encoding/rle.exs
+++ b/exercises/run-length-encoding/rle.exs
@@ -1,0 +1,18 @@
+defmodule RunLengthEncoder do 
+  @doc """
+  Generates a string where consecutive elements are represented as a data value and count.
+  "HORSE" => "1H1O1R1S1E"
+  For this example, assume all input are strings, that are all uppercase letters.
+  It should also be able to reconstruct the data into its original form. 
+  "1H1O1R1S1E" => "HORSE" 
+  """
+  @spec encode(string) :: String.t
+  def encode(string) do
+  
+  end
+
+  @spec encode(string) :: String.t
+  def decode(string) do
+    
+  end
+end

--- a/exercises/run-length-encoding/rle_test.exs
+++ b/exercises/run-length-encoding/rle_test.exs
@@ -1,0 +1,41 @@
+if System.get_env("EXERCISM_TEST_EXAMPLES") do
+  Code.load_file("example.exs")
+else
+  Code.load_file("rle.exs")
+end
+
+ExUnit.start
+ExUnit.configure exclude: :pending, trace: true
+
+defmodule RunLengthEncoderTest do
+  use ExUnit.Case
+
+  test "empty string returns empty" do
+    assert RunLengthEncoder.encode("") === ""
+  end
+
+  @tag :pending
+  test "simple string gets encoded" do
+    assert RunLengthEncoder.encode("AAA") === "3A"
+  end
+
+  @tag :pending
+  test "more complicated string" do
+    assert RunLengthEncoder.encode("HORSE") == "1H1O1R1S1E"
+  end
+
+  @tag :pending
+  test "an even more complex string" do
+    assert RunLengthEncoder.encode("WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB") === "12W1B12W3B24W1B"
+  end
+
+  @tag :pending
+  test "it decodes an encoded simple string" do
+    assert RunLengthEncoder.decode("3A") === "AAA"
+  end
+
+  @tag :pending
+  test "it decodes a more complicated string" do
+    assert RunLengthEncoder.decode("12W1B12W3B24W1B") === "WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB"
+  end
+end


### PR DESCRIPTION
I have been looking through [X-common](https://github.com/exercism/x-common) and trying to add more `Elixir` exercises, so here is [Run-Length-Encoding](https://github.com/exercism/x-common/blob/master/run-length-encoding.md). The test suite reflects the `README`. Let me know if you think we should add more test cases or anything. Thanks! :tada: 

- [x] `config.json` updated.
- [x] `test, example, and template` files added
- [x] All tests are :green_heart: 