### PR TITLE
Fix string warning messages in tests

### DIFF
--- a/exercises/acronym/example.exs
+++ b/exercises/acronym/example.exs
@@ -1,6 +1,6 @@
 defmodule Acronym do
-  
-  @spec abbreviate(string) :: String.t()
+
+  @spec abbreviate(String.t()) :: String.t()
   def abbreviate(string) do
     Regex.scan(~r/[A-Z]+[a-z]*|[a-z]+/, string)
     |> List.flatten

--- a/exercises/run-length-encoding/example.exs
+++ b/exercises/run-length-encoding/example.exs
@@ -1,12 +1,12 @@
-defmodule RunLengthEncoder do 
+defmodule RunLengthEncoder do
 
-  @spec encode(string) :: String.t
+  @spec encode(String.t) :: String.t
   def encode(string) do
     Regex.scan(~r/([A-Z])\1*/, string)
     |> Enum.map_join(fn([run, c]) -> "#{String.length(run)}#{c}" end)
   end
 
-  @spec decode(string) :: String.t
+  @spec decode(String.t) :: String.t
   def decode(string) do
     Regex.scan(~r/(\d+)(.)/, string)
     |> Enum.map_join(fn [_,n,c] -> String.duplicate(c, String.to_integer(n)) end)

--- a/exercises/run-length-encoding/rle.exs
+++ b/exercises/run-length-encoding/rle.exs
@@ -1,18 +1,18 @@
-defmodule RunLengthEncoder do 
+defmodule RunLengthEncoder do
   @doc """
   Generates a string where consecutive elements are represented as a data value and count.
   "HORSE" => "1H1O1R1S1E"
   For this example, assume all input are strings, that are all uppercase letters.
-  It should also be able to reconstruct the data into its original form. 
-  "1H1O1R1S1E" => "HORSE" 
+  It should also be able to reconstruct the data into its original form.
+  "1H1O1R1S1E" => "HORSE"
   """
-  @spec encode(string) :: String.t
+  @spec encode(String.t) :: String.t
   def encode(string) do
-  
+
   end
 
-  @spec decode(string) :: String.t
+  @spec decode(String.t) :: String.t
   def decode(string) do
-    
+
   end
 end


### PR DESCRIPTION
switched all `@spec` definitions with `string` to `String.t` to fix warnings when tests are run. also stripped some whitespace in the files I was in.

The only other warnings are that `DNA`/`DNATest` are being defined 3 times for `hamming`, `rna_transcription`, and `nucleotide_count` ( dont know if this wants to be changed), and that the inspect protocol already been consolidated (which comes from the way the code is loaded after mix compiles the project)

