### PR TITLE
largest-series-product: Do not test digits/slices

### DIFF
--- a/exercises/largest-series-product/example.exs
+++ b/exercises/largest-series-product/example.exs
@@ -4,11 +4,11 @@ defmodule Series do
   Splits up the given string of numbers into an array of integers.
   """
   @spec digits(String.t) :: [non_neg_integer]
-  def digits("") do
+  defp digits("") do
     []
   end
 
-  def digits(number_string) do
+  defp digits(number_string) do
     String.split(number_string, "", trim: true)
     |> Enum.reduce([], fn(char, acc) -> [String.to_integer(char)|acc] end)
     |> Enum.reverse
@@ -18,7 +18,7 @@ defmodule Series do
   Generates sublists of a given size from a given string of numbers.
   """
   @spec slices(String.t, non_neg_integer) :: [list(non_neg_integer)]
-  def slices(number_string, size) do
+  defp slices(number_string, size) do
     digits = digits(number_string)
     chunk(digits, size, 1)
   end

--- a/exercises/largest-series-product/largest_series_product.exs
+++ b/exercises/largest-series-product/largest_series_product.exs
@@ -1,22 +1,6 @@
 defmodule Series do
 
   @doc """
-  Splits up the given string of numbers into an array of integers.
-  """
-  @spec digits(String.t) :: [non_neg_integer]
-  def digits(number_string) do
-    
-  end
-
-  @doc """
-  Generates sublists of a given size from a given string of numbers.
-  """
-  @spec slices(String.t, non_neg_integer) :: [list(non_neg_integer)]
-  def slices(number_string, size) do
-
-  end
-
-  @doc """
   Finds the largest product of a given number of consecutive numbers in a given string of numbers.
   """
   @spec largest_product(String.t, non_neg_integer) :: non_neg_integer

--- a/exercises/largest-series-product/largest_series_product_test.exs
+++ b/exercises/largest-series-product/largest_series_product_test.exs
@@ -8,51 +8,6 @@ ExUnit.configure exclude: :pending, trace: true
 defmodule LargestSeriesProductTest do
   use ExUnit.Case
 
-  # @tag :pending
-  test "digits" do
-    assert Series.digits("0123456789") == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-  end
-
-  @tag :pending
-  test "same digits reversed" do
-    assert Series.digits("9876543210") == [9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
-  end
-
-  @tag :pending
-  test "fewer digits" do
-    assert Series.digits("87654") == [8, 7, 6, 5, 4]
-  end
-
-  @tag :pending
-  test "some other digits" do
-    assert Series.digits("936923468") == [9, 3, 6, 9, 2, 3, 4, 6, 8]
-  end
-
-  @tag :pending
-  test "slices of zero" do
-    assert Series.digits("") == []
-  end
-
-  @tag :pending
-  test "slices of two" do
-    assert Series.slices("01234", 2) == [[0, 1], [1, 2], [2, 3], [3, 4]]
-  end
-
-  @tag :pending
-  test "other slices of two" do
-    assert Series.slices("98273463", 2) == [[9, 8], [8, 2], [2, 7], [7, 3], [3, 4], [4, 6], [6, 3]]
-  end
-
-  @tag :pending
-  test "slices of three" do
-    assert Series.slices("01234", 3) == [[0, 1, 2], [1, 2, 3], [2, 3, 4]]
-  end
-
-  @tag :pending
-  test "other slices of three" do
-    assert Series.slices("982347", 3) == [[9, 8, 2], [8, 2, 3], [2, 3, 4], [3, 4, 7]]
-  end
-
   @tag :pending
   test "largest product of 2" do
     assert Series.largest_product("0123456789", 2) == 72


### PR DESCRIPTION
The digits and slices functions are internal implementation details and
thus the test case for the largest-series-product problem should not be
concerned with testing them. The series tests could potentially be moved
to the series exercise (which would have to be a new addition to this
track).

Their presence may cause students to falsely think that their solution
has to use these two functions, instead of the alternative
implementation of only iterating through the digits once.

If it is desired to give hints on how to approach this problem (which
was one advantage of having the digits and slices tests), then consider
including a hints file and/or directory in the largest-series-product
directory.

This PR arises from discussion in
https://github.com/exercism/x-common/issues/192