### PR TITLE
Fix saddle points test

### DIFF
--- a/exercises/saddle-points/example.exs
+++ b/exercises/saddle-points/example.exs
@@ -6,13 +6,13 @@ defmodule Matrix do
   @spec rows(String.t()) :: [[integer]]
   def rows(str) do
     str
-    |> String.split("\n", trim: true)
+    |> String.split("\n")
     |> Enum.map(&parse_row/1)
   end
 
   defp parse_row(str) do
     str
-    |> String.split(" ", trim: true)
+    |> String.split(" ")
     |> Enum.map(&String.to_integer/1)
   end
 

--- a/exercises/saddle-points/saddle_points_test.exs
+++ b/exercises/saddle-points/saddle_points_test.exs
@@ -34,7 +34,7 @@ defmodule SaddlePointsTest do
 
   @tag :pending
   test "extract a column" do
-    columns = Matrix.columns("1 2 3\n4 5 6\n7 8 9\n 8 7 6")
+    columns = Matrix.columns("1 2 3\n4 5 6\n7 8 9\n8 7 6")
     assert Enum.at(columns, 0) == [1, 4, 7, 8]
   end
 


### PR DESCRIPTION
This saddle point test should not have the random space after a newline character.

I originally made this exercise by taking the ruby version's tests, which means this error is most likely on the ruby version as well, although string splitting is treated differently between ruby/elixir so it's not a problem there