### PR TITLE
Fix map type and make it consistent

### DIFF
--- a/exercises/etl/etl.exs
+++ b/exercises/etl/etl.exs
@@ -7,7 +7,7 @@ defmodule ETL do
   iex> ETL.transform(%{"a" => ["ABILITY", "AARDVARK"], "b" => ["BALLAST", "BEAUTY"]})
   %{"ability" => "a", "aardvark" => "a", "ballast" => "b", "beauty" =>"b"}
   """
-  @spec transform(Map) :: map()
+  @spec transform(map) :: map
   def transform(input) do
 
   end

--- a/exercises/nucleotide-count/dna.exs
+++ b/exercises/nucleotide-count/dna.exs
@@ -26,7 +26,7 @@ defmodule DNA do
   iex> DNA.histogram('AATAA')
   %{?A => 4, ?T => 1, ?C => 0, ?G => 0}
   """
-  @spec histogram([char]) :: Map
+  @spec histogram([char]) :: map
   def histogram(strand) do
 
   end

--- a/exercises/palindrome-products/example.exs
+++ b/exercises/palindrome-products/example.exs
@@ -3,8 +3,8 @@ defmodule Palindromes do
   @doc """
   Generates all palindrome products from an optionally given min factor (or 1) to a given max factor.
   """
-  @spec generate(non_neg_integer) :: map()
-  @spec generate(non_neg_integer, non_neg_integer) :: map()
+  @spec generate(non_neg_integer) :: map
+  @spec generate(non_neg_integer, non_neg_integer) :: map
   def generate(max_factor, min_factor \\ 1) do
     Enum.reduce(min_factor..max_factor, %{}, fn(x, dict) ->
       Enum.reduce(x..max_factor, dict, fn(y, products) ->

--- a/exercises/palindrome-products/palindrome_products.exs
+++ b/exercises/palindrome-products/palindrome_products.exs
@@ -3,7 +3,7 @@ defmodule Palindromes do
   @doc """
   Generates all palindrome products from an optionally given min factor (or 1) to a given max factor.
   """
-  @spec generate(non_neg_integer, non_neg_integer) :: map() 
+  @spec generate(non_neg_integer, non_neg_integer) :: map
   def generate(max_factor, min_factor \\ 1) do
     
   end

--- a/exercises/parallel-letter-frequency/frequency.exs
+++ b/exercises/parallel-letter-frequency/frequency.exs
@@ -6,7 +6,7 @@ defmodule Frequency do
 
   The number of worker processes to use can be set with 'workers'.
   """
-  @spec frequency([String.t], pos_integer) :: Map
+  @spec frequency([String.t], pos_integer) :: map
   def frequency(texts, workers) do
 
   end

--- a/exercises/word-count/word_count.exs
+++ b/exercises/word-count/word_count.exs
@@ -4,7 +4,7 @@ defmodule Words do
 
   Words are compared case-insensitively.
   """
-  @spec count(String.t) :: map()
+  @spec count(String.t) :: map
   def count(sentence) do
 
   end


### PR DESCRIPTION
A few places were using `Map` as a type, which technically means the
atom `:'Elixir.Map'`.  The type should be `map`.  There was also some
inconsistency of `map` vs `map()`.  It seems that for the most part the
exercises aren't using `()` when unnecessary, so I changed the existing
instances of `map()` to just `map`.