### PR TITLE
Comment out first pending tag in test

### DIFF
--- a/exercises/largest-series-product/largest_series_product_test.exs
+++ b/exercises/largest-series-product/largest_series_product_test.exs
@@ -8,7 +8,7 @@ ExUnit.configure exclude: :pending, trace: true
 defmodule LargestSeriesProductTest do
   use ExUnit.Case
 
-  @tag :pending
+  # @tag :pending
   test "largest product of 2" do
     assert Series.largest_product("0123456789", 2) == 72
   end


### PR DESCRIPTION
The first test in the test file should have the pending tag commented out.