### PR TITLE
Extra queen attack tests for drawing the board.

### DIFF
--- a/exercises/queen-attack/queen_attack_test.exs
+++ b/exercises/queen-attack/queen_attack_test.exs
@@ -78,6 +78,38 @@ _ _ _ _ _ _ _ _
   end
 
   @tag :pending
+  test "queen placed on the bottom right corner" do
+    queens = Queens.new({4, 3}, {7, 7})
+    board = String.strip """
+_ _ _ _ _ _ _ _
+_ _ _ _ _ _ _ _
+_ _ _ _ _ _ _ _
+_ _ _ _ _ _ _ _
+_ _ _ W _ _ _ _
+_ _ _ _ _ _ _ _
+_ _ _ _ _ _ _ _
+_ _ _ _ _ _ _ B
+    """
+    assert Queens.to_string(queens) == board
+  end
+
+  @tag :pending
+  test "queen placed on the edge of the board" do
+    queens = Queens.new({4, 3}, {2, 7})
+    board = String.strip """
+_ _ _ _ _ _ _ _
+_ _ _ _ _ _ _ _
+_ _ _ _ _ _ _ B
+_ _ _ _ _ _ _ _
+_ _ _ W _ _ _ _
+_ _ _ _ _ _ _ _
+_ _ _ _ _ _ _ _
+_ _ _ _ _ _ _ _
+    """
+    assert Queens.to_string(queens) == board
+  end
+
+  @tag :pending
   test "cannot attack" do
     queens = Queens.new({2, 3}, {4, 7})
     refute Queens.can_attack?(queens)


### PR DESCRIPTION
This adds two new tests for queens that are placed on the edges of the board. This would test scenarios that the other representation tests don't cover.