### PR TITLE
Fix deprecation of \x{H*} in ForthTest

### DIFF
--- a/exercises/forth/forth_test.exs
+++ b/exercises/forth/forth_test.exs
@@ -26,7 +26,7 @@ defmodule ForthTest do
   test "non-word characters are separators" do
     # Note the Ogham Space Mark ( ), this is a spacing character.
     s = Forth.new
-        |> Forth.eval("1\x{000}2\x{001}3\n4\r5 6\t7")
+        |> Forth.eval("1\x002\x013\n4\r5 6\t7")
         |> Forth.format_stack
     assert s == "1 2 3 4 5 6 7"
   end


### PR DESCRIPTION
I'm running my Exercism tests on Elixir 1.3-dev, and got a deprecation warning in ForthTest:

```
warning: \x{H*} inside strings/sigils/chars is deprecated, please use \xHH (byte) or \uHHHH (codepoint) instead
```

The fix isn't exactly an improvement in terms of readability, but it satisfies the compiler.
I've tested this with Elixir 1.3-dev (current master) and 1.2.5.