### PR TITLE
PalindromeProductsTest overspecify the order of generated factors

### DIFF
--- a/exercises/palindrome-products/palindrome_products_test.exs
+++ b/exercises/palindrome-products/palindrome_products_test.exs
@@ -12,7 +12,7 @@ defmodule PalindromeProductsTest do
   test "largest palindrome from single digit factors" do
     palindromes = Palindromes.generate(9)
     assert (palindromes |> Map.keys |> Enum.sort |> List.last) == 9
-    assert palindromes[9] == [[1, 9], [3, 3]]
+    assert Enum.sort(palindromes[9]) == [[1, 9], [3, 3]]
   end
 
   @tag :pending


### PR DESCRIPTION
My implementation of Palindrome used `Enum.group_by/2`. I remember struggling a bit to satisfy the test suite's assertions. They are expressed in terms of list equality, so factors for 9 must be `[[1, 9], [3, 3]]`, in that order.

I think these tests shouldn't be concerned with order. It is further complicated by changed behaviour of `Enum.group_by/2` in Elixir 1.3-dev, where it now keeps the order of the original list in the grouped sublists whereas in 1.2.5 it would reverse the order, meaning my implementation fails after upgrading Elixir.

It only hits one test case, because there's only one test case with multiple factor pairs. I've done the minimal change, but one could do the sort in all test cases to guard against regression if there are ever new test cases added.