### PR TITLE
Correcting Luhn test case to be a valid number.

### DIFF
--- a/exercises/luhn/luhn_test.exs
+++ b/exercises/luhn/luhn_test.exs
@@ -24,7 +24,7 @@ defmodule LuhnTest do
 
   @tag :pending
   test "valid number" do
-    assert Luhn.valid?("8739567") == true
+    assert Luhn.valid?("8639567") == true
   end
 
   @tag :pending


### PR DESCRIPTION
The test case for a valid number was incorrect (the checksum == 41)