### PR TITLE
Adding more documentation for contributers

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ The exercises currently target Elixir 1.2. Detailed installation instructions ca
 
 Thank you so much for contributing! :tada:
 
-Please start by reading the general Exercism [contributing guide](https://github.com/exercism/x-api/blob/master/CONTRIBUTING.md#the-exercise-data).
-
 We welcome pull requests that provide fixes and improvements to existing exercises. If you're unsure, then go ahead and open a GitHub issue, and we'll discuss the change.
 
 Please keep the following in mind:
+
+- Please start by reading the general Exercism [contributing guide](https://github.com/exercism/x-api/blob/master/CONTRIBUTING.md#the-exercise-data).
 
 - Pull requests should be focused on a single exercise, issue, or change.
 


### PR DESCRIPTION
There was some question about how to make the `config.json` file a bit more
discoverable, so I figured documentation was a good place to start with that.
This way people know what that file is for, know that the order matters, and
also know to add their new exercise to that file when they are adding a new one
to the repo.

This addresses [this comment](https://github.com/exercism/xelixir/pull/184#discussion_r64992425) by @kytrinyx.