### PR TITLE
Supres elixir warning

### DIFF
--- a/exercises/acronym/acronym.exs
+++ b/exercises/acronym/acronym.exs
@@ -3,7 +3,7 @@ defmodule Acronym do
   Generate an acronym from a string. 
   "This is a string" => "TIAS"
   """
-  @spec abbreviate(string) :: String.t()
+  @spec abbreviate(String.t()) :: String.t()
   def abbreviate(string) do
    
   end


### PR DESCRIPTION
Fix the following warning (I use [`elixir-1.3.0-rc.1`](https://github.com/elixir-lang/elixir/releases/tag/v1.3.0-rc.1)):

```
warning: string() type use is discouraged. For character lists, use charlist() type, for strings, String.t()
    acronym.exs:6: Acronym (module)
```