### PR TITLE
acronym.exs whitespace

### DIFF
--- a/exercises/acronym/acronym.exs
+++ b/exercises/acronym/acronym.exs
@@ -1,10 +1,10 @@
 defmodule Acronym do
   @doc """
-  Generate an acronym from a string. 
+  Generate an acronym from a string.
   "This is a string" => "TIAS"
   """
   @spec abbreviate(String.t()) :: String.t()
   def abbreviate(string) do
-   
+    
   end
 end


### PR DESCRIPTION
Remove trailing whitespace; make method body be two-space indent.