### PR TITLE
Suggesting a different API for the Hamming exercise

### DIFF
--- a/exercises/hamming/example.exs
+++ b/exercises/hamming/example.exs
@@ -1,16 +1,17 @@
 defmodule DNA do
   @doc """
-  Compute the hamming distance between two character lists.
+  Returns number of differences between two strands of DNA, known as the Hamming Distance.
 
   ## Examples
 
-  iex> DNA.hamming_distance('ACCAGGG', 'ACTATGG')
-  2
+  iex> DNA.hamming_distance('AAGTCATA', 'TAGCGATC')
+  4
   """
-  def hamming_distance(strand1, strand2) when length(strand1) == length(strand2) do
-    pairs(strand1, strand2) |> count_mismatched
+  def hamming_distance(strand1, strand2) when length(strand1) === length(strand2) do
+    distance = pairs(strand1, strand2) |> count_mismatched
+    {:ok, distance}
   end
-  def hamming_distance(_, _), do: nil
+  def hamming_distance(_, _), do: {:error, "Lists must be the same length"}
 
   defp pairs(s1, s2),           do: Enum.zip(s1, s2)
   defp count_mismatched(pairs), do: Enum.count(pairs, fn({c1, c2}) -> c2 && (c1 != c2) end)

--- a/exercises/hamming/example.exs
+++ b/exercises/hamming/example.exs
@@ -5,7 +5,7 @@ defmodule DNA do
   ## Examples
 
   iex> DNA.hamming_distance('AAGTCATA', 'TAGCGATC')
-  4
+  {:ok, 4}
   """
   def hamming_distance(strand1, strand2) when length(strand1) === length(strand2) do
     distance = pairs(strand1, strand2) |> count_mismatched

--- a/exercises/hamming/hamming.exs
+++ b/exercises/hamming/hamming.exs
@@ -5,7 +5,7 @@ defmodule DNA do
   ## Examples
 
   iex> DNA.hamming_distance('AAGTCATA', 'TAGCGATC')
-  4
+  {:ok, 4}
   """
   @spec hamming_distance([char], [char]) :: non_neg_integer
   def hamming_distance(strand1, strand2) do

--- a/exercises/hamming/hamming_test.exs
+++ b/exercises/hamming/hamming_test.exs
@@ -9,45 +9,38 @@ defmodule DNATest do
   use ExUnit.Case
 
 #   @tag :pending
-  test "hamming distance for strands of same length returns :ok" do
-    {code, _} = DNA.hamming_distance('', '')
-    assert code == :ok
+  test "hamming distance for strands of the same length are ok" do
+    assert {:ok, _} = DNA.hamming_distance('', '')
   end
 
   @tag :pending
   test "hamming distance is undefined for strands of different lengths" do
-    assert DNA.hamming_distance('AAAC', 'TAGGGGAGGCTAGCGGTAGGAC') == {:error, "Lists must be the same length."}
-    assert DNA.hamming_distance('GACTACGGACAGGACACC', 'GACATCGC') == {:error, "Lists must be the same length."}
+    assert {:error, "Lists must be the same length."} = DNA.hamming_distance('AAAC', 'TAGGGGAGGCTAGCGGTAGGAC')
+    assert {:error, "Lists must be the same length."} = DNA.hamming_distance('GACTACGGACAGGACACC', 'GACATCGC')
   end
 
   @tag :pending
   test "no difference between empty strands" do
-    {:ok, distance} = DNA.hamming_distance('', '')
-    assert distance == 0
+    assert {:ok, 0} = DNA.hamming_distance('', '')
   end
 
   @tag :pending
   test "no difference between identical strands" do
-    {:ok, distance} = DNA.hamming_distance('GGACTGA', 'GGACTGA')
-    assert distance == 0
+    assert {:ok, 0} = DNA.hamming_distance('GGACTGA', 'GGACTGA')
   end
 
   @tag :pending
   test "small hamming distance in middle somewhere" do
-    {:ok, distance} = DNA.hamming_distance('GGACG', 'GGTCG')
-    assert distance == 1
+    assert {:ok, 1} = DNA.hamming_distance('GGACG', 'GGTCG')
   end
 
   @tag :pending
   test "distance with same nucleotides in different locations" do
-    {:ok, distance} = DNA.hamming_distance('TAG', 'GAT')
-    assert distance == 2
+    assert {:ok, 2} = DNA.hamming_distance('TAG', 'GAT')
   end
 
   @tag :pending
   test "larger distance" do
-    {:ok, distance} = DNA.hamming_distance('ACCAGGG', 'ACTATGG')
-    assert distance == 2
+    assert {:ok, 2} = DNA.hamming_distance('ACCAGGG', 'ACTATGG')
   end
-
 end

--- a/exercises/hamming/hamming_test.exs
+++ b/exercises/hamming/hamming_test.exs
@@ -8,39 +8,33 @@ ExUnit.configure exclude: :pending, trace: true
 defmodule DNATest do
   use ExUnit.Case
 
-#   @tag :pending
-  test "hamming distance for strands of the same length are ok" do
-    assert {:ok, _} = DNA.hamming_distance('', '')
+  test "no difference between empty strands" do
+    assert DNA.hamming_distance('', '') == {:ok, 0}
+  end
+
+  @tag :pending
+  test "no difference between identical strands" do
+    assert DNA.hamming_distance('GGACTGA', 'GGACTGA') == {:ok, 0}
+  end
+
+  @tag :pending
+  test "small hamming distance in middle somewhere" do
+    assert DNA.hamming_distance('GGACG', 'GGTCG') == {:ok, 1}
+  end
+
+  @tag :pending
+  test "distance with same nucleotides in different locations" do
+    assert DNA.hamming_distance('TAG', 'GAT') == {:ok, 2}
+  end
+
+  @tag :pending
+  test "larger distance" do
+    assert DNA.hamming_distance('ACCAGGG', 'ACTATGG') == {:ok, 2}
   end
 
   @tag :pending
   test "hamming distance is undefined for strands of different lengths" do
     assert {:error, "Lists must be the same length."} = DNA.hamming_distance('AAAC', 'TAGGGGAGGCTAGCGGTAGGAC')
     assert {:error, "Lists must be the same length."} = DNA.hamming_distance('GACTACGGACAGGACACC', 'GACATCGC')
-  end
-
-  @tag :pending
-  test "no difference between empty strands" do
-    assert {:ok, 0} = DNA.hamming_distance('', '')
-  end
-
-  @tag :pending
-  test "no difference between identical strands" do
-    assert {:ok, 0} = DNA.hamming_distance('GGACTGA', 'GGACTGA')
-  end
-
-  @tag :pending
-  test "small hamming distance in middle somewhere" do
-    assert {:ok, 1} = DNA.hamming_distance('GGACG', 'GGTCG')
-  end
-
-  @tag :pending
-  test "distance with same nucleotides in different locations" do
-    assert {:ok, 2} = DNA.hamming_distance('TAG', 'GAT')
-  end
-
-  @tag :pending
-  test "larger distance" do
-    assert {:ok, 2} = DNA.hamming_distance('ACCAGGG', 'ACTATGG')
   end
 end

--- a/exercises/hamming/hamming_test.exs
+++ b/exercises/hamming/hamming_test.exs
@@ -8,34 +8,46 @@ ExUnit.configure exclude: :pending, trace: true
 defmodule DNATest do
   use ExUnit.Case
 
-  # @tag :pending
-  test "no difference between empty strands" do
-    assert DNA.hamming_distance('', '') == 0
-  end
-
-  @tag :pending
-  test "no difference between identical strands" do
-    assert DNA.hamming_distance('GGACTGA', 'GGACTGA') == 0
-  end
-
-  @tag :pending
-  test "small hamming distance in middle somewhere" do
-    assert DNA.hamming_distance('GGACG', 'GGTCG') == 1
-  end
-
-  @tag :pending
-  test "distance with same nucleotides in different locations" do
-    assert DNA.hamming_distance('TAG', 'GAT') == 2
-  end
-
-  @tag :pending
-  test "larger distance" do
-    assert DNA.hamming_distance('ACCAGGG', 'ACTATGG') == 2
+#   @tag :pending
+  test "hamming distance for strands of same length returns :ok" do
+    {code, _} = DNA.hamming_distance('', '')
+    assert code == :ok
   end
 
   @tag :pending
   test "hamming distance is undefined for strands of different lengths" do
-    assert DNA.hamming_distance('AAAC', 'TAGGGGAGGCTAGCGGTAGGAC') == nil
-    assert DNA.hamming_distance('GACTACGGACAGGACACC', 'GACATCGC') == nil
+    assert DNA.hamming_distance('AAAC', 'TAGGGGAGGCTAGCGGTAGGAC') == {:error, "Lists must be the same length."}
+    assert DNA.hamming_distance('GACTACGGACAGGACACC', 'GACATCGC') == {:error, "Lists must be the same length."}
   end
+
+  @tag :pending
+  test "no difference between empty strands" do
+    {:ok, distance} = DNA.hamming_distance('', '')
+    assert distance == 0
+  end
+
+  @tag :pending
+  test "no difference between identical strands" do
+    {:ok, distance} = DNA.hamming_distance('GGACTGA', 'GGACTGA')
+    assert distance == 0
+  end
+
+  @tag :pending
+  test "small hamming distance in middle somewhere" do
+    {:ok, distance} = DNA.hamming_distance('GGACG', 'GGTCG')
+    assert distance == 1
+  end
+
+  @tag :pending
+  test "distance with same nucleotides in different locations" do
+    {:ok, distance} = DNA.hamming_distance('TAG', 'GAT')
+    assert distance == 2
+  end
+
+  @tag :pending
+  test "larger distance" do
+    {:ok, distance} = DNA.hamming_distance('ACCAGGG', 'ACTATGG')
+    assert distance == 2
+  end
+
 end


### PR DESCRIPTION
While doing this problem, I originally missed 'un-pending' the final test. When I did, I realized that there were two types (Integer and Nil) possibly returning from the `hamming_distance/2` function. I'd like to propose a single type return with the idiomatic `:ok` `:error` tuple pattern for handling un-resolved use cases. If a hamming distance is undefined for strands of different lengths (and not considered `0`), it seems returning the error tuple is more informative than a `nil` return and ensures a consistent tuple data type being returned from the query.

This Pull Request:

- includes an updated example solution using the same method solutions as the original exercise
- re-organizes the tests and adds an additional test to direct the solution earlier in the exercise

I'm uncertain if this type of PR is accepted, so I am perfectly fine with a close, but for whatever reason the API in this particular exercise seemed flawed. 

As a relative new comer to the Elixir language, I'm unsure if there is a better pattern for tuple checks than I used in the tests. It seems a little redundant to create a local from the return to pull the value out of the tuple but I don't know a better baked in solution to ExUnit. I'd be happy to update the tests to use a better matcher, or whatever would be most idiomatic for the language. 

Thanks for the hard work and the opportunity to submit a contribution.
