### PR TITLE
Add 'kindergarten-garden'

### DIFF
--- a/config.json
+++ b/config.json
@@ -28,6 +28,7 @@
     "grade-school",
     "list-ops",
     "leap",
+    "kindergarten-garden",
     "etl",
     "meetup",
     "grains",

--- a/exercises/kindergarten-garden/example.exs
+++ b/exercises/kindergarten-garden/example.exs
@@ -1,0 +1,53 @@
+defmodule Garden do
+  @default_names [:alice, :bob, :charlie, :david, :eve, :fred, :ginny, :harriet,
+                  :ileana, :joseph, :kincaid, :larry]
+  @letter_map %{"V" => :violets, "R" => :radishes, "C" => :clover, "G" => :grass}
+
+  @doc """
+    Accepts a string representing the arrangement of cups on a windowsill and a
+    list with names of students in the class. The student names list does not
+    have to be in alphabetical order.
+
+    It decodes that string into the various gardens for each student and returns
+    that information in a map.
+  """
+
+  @spec info(String.t(), list) :: map
+  def info(info_string, student_names \\ @default_names) do
+    student_names = Enum.sort(student_names)
+    map = create_map(student_names)
+    [first_row, second_row] = String.split(info_string, "\n")
+    populate_map(first_row, second_row, map, student_names)
+  end
+
+  defp create_map(student_names) do
+    create_map(student_names, %{})
+  end
+
+  defp create_map([], map), do: map
+
+  defp create_map([h | t], map) do
+    map = Map.put(map, h, nil)
+    create_map(t, map)
+  end
+
+  defp populate_map(_, _, map, []), do: map
+
+  defp populate_map(first_row, second_row, map, [current_name | student_names]) do
+    first_row_letters = String.slice(first_row, 0..1)
+    second_row_letters = String.slice(second_row, 0..1)
+    letters = "#{first_row_letters}#{second_row_letters}"
+    map = add_to_map(map, current_name, letters)
+
+    first_row = String.slice(first_row, 2..-1)
+    second_row = String.slice(second_row, 2..-1)
+    populate_map(first_row, second_row, map, student_names)
+  end
+
+  defp add_to_map(map, current_name, letters) do
+    letters = String.codepoints(letters)
+    translated_list = Enum.map(letters, fn(letter) -> @letter_map[letter] end)
+    tuple = List.to_tuple(translated_list) 
+    Map.put(map, current_name, tuple)
+  end
+end

--- a/exercises/kindergarten-garden/garden.exs
+++ b/exercises/kindergarten-garden/garden.exs
@@ -1,0 +1,14 @@
+defmodule Garden do
+  @doc """
+    Accepts a string representing the arrangement of cups on a windowsill and a
+    list with names of students in the class. The student names list does not
+    have to be in alphabetical order.
+
+    It decodes that string into the various gardens for each student and returns
+    that information in a map.
+  """
+
+  @spec info(String.t(), list) :: map
+  def info(info_string, student_names) do
+  end
+end

--- a/exercises/kindergarten-garden/garden_test.exs
+++ b/exercises/kindergarten-garden/garden_test.exs
@@ -1,0 +1,77 @@
+if !System.get_env("EXERCISM_TEST_EXAMPLES") do
+  Code.load_file("garden.exs")
+end
+
+ExUnit.start
+ExUnit.configure exclude: :pending, trace: true
+
+defmodule GardenTest do
+  use ExUnit.Case
+
+  test "gets the garden for Alice with just her plants" do
+    garden_info = Garden.info("RC\nGG")
+    assert garden_info.alice == {:radishes, :clover, :grass, :grass} 
+  end
+
+  @tag :pending
+  test "gets another garden for Alice with just her plants" do
+    garden_info = Garden.info("VC\nRC")
+    assert garden_info.alice == {:violets, :clover, :radishes, :clover}
+  end
+
+  @tag :pending
+  test "returns an empty tuple if the child has no plants" do
+    garden_info = Garden.info("VC\nRC")
+    assert garden_info.bob == {}
+  end
+
+  @tag :pending
+  test "gets the garden for Bob" do
+    garden_info = Garden.info("VVCG\nVVRC")
+    assert garden_info.bob == {:clover, :grass, :radishes, :clover}
+  end
+
+  @tag :pending
+  test "gets the garden for all students" do
+    garden_info = Garden.info("VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV")
+    assert garden_info.alice == {:violets, :radishes, :violets, :radishes}
+    assert garden_info.bob == {:clover, :grass, :clover, :clover}
+    assert garden_info.charlie == {:violets, :violets, :clover, :grass}
+    assert garden_info.david == {:radishes, :violets, :clover, :radishes}
+    assert garden_info.eve == {:clover, :grass, :radishes, :grass}
+    assert garden_info.fred == {:grass, :clover, :violets, :clover}
+    assert garden_info.ginny == {:clover, :grass, :grass, :clover}
+    assert garden_info.harriet == {:violets, :radishes, :radishes, :violets}
+    assert garden_info.ileana == {:grass, :clover, :violets, :clover}
+    assert garden_info.joseph == {:violets, :clover, :violets, :grass}
+    assert garden_info.kincaid == {:grass, :clover, :clover, :grass}
+    assert garden_info.larry == {:grass, :violets, :clover, :violets}
+  end
+
+  @tag :pending
+  test "accepts custom child names" do
+    garden_info = Garden.info("VC\nRC", [:nate, :maggie])
+    assert garden_info.maggie == {:violets, :clover, :radishes, :clover}
+    assert garden_info.nate == {}
+  end
+
+  @tag :pending
+  test "gets the garden for all students with custom child names" do
+    names = [:maggie, :nate, :xander, :ophelia, :pete, :reggie, :sylvia,
+             :tanner, :ursula, :victor, :winnie, :ynold]
+    garden_string = "VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV"
+    garden_info = Garden.info(garden_string, names)
+    assert garden_info.maggie == {:violets, :radishes, :violets, :radishes}
+    assert garden_info.nate == {:clover, :grass, :clover, :clover}
+    assert garden_info.ophelia == {:violets, :violets, :clover, :grass}
+    assert garden_info.pete == {:radishes, :violets, :clover, :radishes}
+    assert garden_info.reggie == {:clover, :grass, :radishes, :grass}
+    assert garden_info.sylvia == {:grass, :clover, :violets, :clover}
+    assert garden_info.tanner == {:clover, :grass, :grass, :clover}
+    assert garden_info.ursula == {:violets, :radishes, :radishes, :violets}
+    assert garden_info.victor == {:grass, :clover, :violets, :clover}
+    assert garden_info.winnie == {:violets, :clover, :violets, :grass}
+    assert garden_info.xander == {:grass, :clover, :clover, :grass}
+    assert garden_info.ynold == {:grass, :violets, :clover, :violets}
+  end
+end


### PR DESCRIPTION
This adds the kindergarten garden exercise. There wasn't a set of example data
that we had in the x-common repo, so I chose to mimic the tests from the Ruby
implementation (i.e. adding the ability to pass in custom names, which wasn't
expressly stated in the Readme).

I'm hoping that the tests that I set up are generic enough to offer various
ways of solving this problem and that they're not too prescriptive.