### PR TITLE
Remove deprecated `HashSet` from allergies

### DIFF
--- a/exercises/allergies/allergies_test.exs
+++ b/exercises/allergies/allergies_test.exs
@@ -72,9 +72,9 @@ defmodule AllergiesTest do
   end
 
   defp assert_is_a_set_containing(list, to_contain) do
-    set = Enum.into(list, HashSet.new)
+    set = Enum.into(list, MapSet.new)
     same_contents = to_contain
-      |> Enum.into(HashSet.new)
+      |> Enum.into(MapSet.new)
       |> Set.equal?(set)
     assert same_contents,
            "Expected a set with: #{inspect to_contain} got #{inspect set |> Set.to_list}"


### PR DESCRIPTION
We still had a reference to `HashSet`, which is now deprecated, in the
`allergies` test. This replaces that with the new `MapSet` which replaced the
old module.

This fixes #209