### PR TITLE
Update Elixir and Erlang versions, add check for trailing whitespace

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,14 @@
 ---
 language: elixir
 elixir:
-  - 1.2.0-rc.0
+  - 1.3.2
 otp_release:
-  - 18.1
+  - 19.0
 
 script:
 - bin/fetch-configlet
 - bin/configlet .
 - mix deps.get
 - mix test
+- "! git grep ' $' -- \\*.exs | grep -v -e 'exercises/diamond/diamond_test.exs'"
 sudo: false

--- a/exercises/acronym/acronym.exs
+++ b/exercises/acronym/acronym.exs
@@ -5,6 +5,5 @@ defmodule Acronym do
   """
   @spec abbreviate(String.t()) :: String.t()
   def abbreviate(string) do
-    
   end
 end

--- a/exercises/atbash-cipher/atbash.exs
+++ b/exercises/atbash-cipher/atbash.exs
@@ -9,6 +9,5 @@ defmodule Atbash do
   """
   @spec encode(String.t) :: String.t
   def encode(plaintext) do
-  
   end
 end

--- a/exercises/bank-account/account.exs
+++ b/exercises/bank-account/account.exs
@@ -13,7 +13,6 @@ defmodule BankAccount do
   """
   @spec open_bank() :: account
   def open_bank() do
-  
   end
 
   @doc """
@@ -21,7 +20,6 @@ defmodule BankAccount do
   """
   @spec close_bank(account) :: none
   def close_bank(account) do
-  
   end
 
   @doc """
@@ -29,14 +27,12 @@ defmodule BankAccount do
   """
   @spec balance(account) :: integer
   def balance(account) do
-  
   end
- 
+
   @doc """
   Update the account's balance by adding the given amount which may be negative.
   """
   @spec update(account, integer) :: any
   def update(account, amount) do
-  
   end
 end

--- a/exercises/binary/binary.exs
+++ b/exercises/binary/binary.exs
@@ -6,6 +6,5 @@ defmodule Binary do
   """
   @spec to_decimal(String.t) :: non_neg_integer
   def to_decimal(string) do
-  
   end
 end

--- a/exercises/bowling/bowling_test.exs
+++ b/exercises/bowling/bowling_test.exs
@@ -163,7 +163,7 @@ defmodule BowlingTest do
     game = roll_reduce(game, rolls)
     assert Bowling.score(game) == 32
   end
-  
+
   @tag :pending
   test "fills out the last frame when there is a strike" do
     game = Bowling.start
@@ -249,7 +249,7 @@ defmodule BowlingTest do
     game = Bowling.start
     assert Bowling.roll(game, 11) == {:error, "Pins must have a value from 0 to 10"}
   end
-  
+
   @tag :pending
   test "does not allow consecutive rolls to be greater than a strike" do
     game = Bowling.start

--- a/exercises/largest-series-product/largest_series_product.exs
+++ b/exercises/largest-series-product/largest_series_product.exs
@@ -5,6 +5,6 @@ defmodule Series do
   """
   @spec largest_product(String.t, non_neg_integer) :: non_neg_integer
   def largest_product(number_string, size) do
-   
+
   end
 end

--- a/exercises/leap/leap.exs
+++ b/exercises/leap/leap.exs
@@ -10,6 +10,6 @@ defmodule Year do
   """
   @spec leap_year?(non_neg_integer) :: boolean
   def leap_year?(year) do
-  
+
   end
 end

--- a/exercises/list-ops/example.exs
+++ b/exercises/list-ops/example.exs
@@ -2,10 +2,10 @@ defmodule ListOps do
   # Please don't use any external modules (especially List) in your
   # implementation. The point of this exercise is to create these basic functions
   # yourself.
-  # 
+  #
   # Note that `++` is a function from an external module (Kernel, which is
   # automatically important`) and so shouldn't be used either.
- 
+
   @spec count(list) :: non_neg_integer
   def count(l), do: do_count(l, 0)
 

--- a/exercises/minesweeper/example.exs
+++ b/exercises/minesweeper/example.exs
@@ -9,7 +9,7 @@ defmodule Minesweeper do
     w = String.length(hd(board)) # Only 7-bit ASCII in the board, so this is safe
     annotations =
       Enum.reduce(Stream.with_index(board), %{}, fn { line, y }, acc ->
-        Enum.reduce(Stream.with_index(String.to_char_list(line)), acc, fn 
+        Enum.reduce(Stream.with_index(String.to_char_list(line)), acc, fn
           { ?*, x }, acc -> add_adjacents(acc, { x, y }, { w, h })
           _, acc         -> acc
         end)

--- a/exercises/nth-prime/nth_prime.exs
+++ b/exercises/nth-prime/nth_prime.exs
@@ -5,7 +5,6 @@ defmodule Prime do
   """
   @spec nth(non_neg_integer) :: non_neg_integer
   def nth(count) do
- 
   end
 
 end

--- a/exercises/palindrome-products/palindrome_products.exs
+++ b/exercises/palindrome-products/palindrome_products.exs
@@ -5,6 +5,5 @@ defmodule Palindromes do
   """
   @spec generate(non_neg_integer, non_neg_integer) :: map
   def generate(max_factor, min_factor \\ 1) do
-    
   end
 end

--- a/exercises/parallel-letter-frequency/example.exs
+++ b/exercises/parallel-letter-frequency/example.exs
@@ -5,7 +5,7 @@ defmodule Frequency do
   Returns a map of characters to frequencies.
   """
   def frequency(texts, workers) do
-    groups = Enum.map(0..(workers-1), &stripe(&1, texts, workers)) 
+    groups = Enum.map(0..(workers-1), &stripe(&1, texts, workers))
     Enum.map(groups, &Frequency.count_texts/1)
     #:rpc.pmap({Frequency, :count_texts}, [], groups)
     |> merge_freqs()

--- a/exercises/phone-number/phone_number.exs
+++ b/exercises/phone-number/phone_number.exs
@@ -18,7 +18,6 @@ defmodule Phone do
   """
   @spec number(String.t) :: String.t
   def number(raw) do
-
   end
 
   @doc """
@@ -40,7 +39,6 @@ defmodule Phone do
   """
   @spec area_code(String.t) :: String.t
   def area_code(raw) do
-  
   end
 
   @doc """
@@ -62,6 +60,5 @@ defmodule Phone do
   """
   @spec pretty(String.t) :: String.t
   def pretty(raw) do
-  
   end
 end

--- a/exercises/prime-factors/prime_factors.exs
+++ b/exercises/prime-factors/prime_factors.exs
@@ -5,7 +5,7 @@ defmodule PrimeFactors do
   The prime factors are prime numbers that when multiplied give the desired
   number.
 
-  The prime factors of 'number' will be ordered lowest to highest. 
+  The prime factors of 'number' will be ordered lowest to highest.
   """
   @spec factors_for(pos_integer) :: [pos_integer]
   def factors_for(number) do

--- a/exercises/pythagorean-triplet/pythagorean_triplet.exs
+++ b/exercises/pythagorean-triplet/pythagorean_triplet.exs
@@ -37,6 +37,5 @@ defmodule Triplet do
   """
   @spec generate(non_neg_integer, non_neg_integer, non_neg_integer) :: [list(non_neg_integer)]
   def generate(min, max, sum) do
-   
   end
 end

--- a/exercises/roman-numerals/roman.exs
+++ b/exercises/roman-numerals/roman.exs
@@ -4,6 +4,5 @@ defmodule Roman do
   """
   @spec numerals(pos_integer) :: String.t
   def numerals(number) do
-  
   end
 end

--- a/exercises/zipper/example.exs
+++ b/exercises/zipper/example.exs
@@ -76,7 +76,7 @@ defmodule Zipper do
              right: r, trail: zt}) do
     %Z{ value: lv, left: ll, right: lr, trail: [{ :left, v, r } | zt] }
   end
-  
+
   @doc """
   Get the right child of the focus node, if any.
   """

--- a/exercises/zipper/zipper.exs
+++ b/exercises/zipper/zipper.exs
@@ -16,7 +16,6 @@ defmodule Zipper do
   """
   @spec from_tree(BT.t) :: Z.t
   def from_tree(bt) do
-
   end
 
   @doc """
@@ -24,7 +23,6 @@ defmodule Zipper do
   """
   @spec to_tree(Z.t) :: BT.t
   def to_tree(z) do
-
   end
 
   @doc """
@@ -32,7 +30,6 @@ defmodule Zipper do
   """
   @spec value(Z.t) :: any
   def value(z) do
-
   end
 
   @doc """
@@ -40,15 +37,13 @@ defmodule Zipper do
   """
   @spec left(Z.t) :: Z.t | nil
   def left(z) do
-
   end
-  
+
   @doc """
   Get the right child of the focus node, if any.
   """
   @spec right(Z.t) :: Z.t | nil
   def right(z) do
-
   end
 
   @doc """
@@ -56,7 +51,6 @@ defmodule Zipper do
   """
   @spec up(Z.t) :: Z.t
   def up(z) do
-
   end
 
   @doc """
@@ -64,22 +58,19 @@ defmodule Zipper do
   """
   @spec set_value(Z.t, any) :: Z.t
   def set_value(z, v) do
-
   end
-  
+
   @doc """
-  Replace the left child tree of the focus node. 
+  Replace the left child tree of the focus node.
   """
   @spec set_left(Z.t, BT.t) :: Z.t
   def set_left(z, l) do
-
   end
-  
+
   @doc """
-  Replace the right child tree of the focus node. 
+  Replace the right child tree of the focus node.
   """
   @spec set_right(Z.t, BT.t) :: Z.t
   def set_right(z, r) do
-
   end
 end


### PR DESCRIPTION
Issue #159 was about failing the build based on the presence of trailing
whitespace. This adds that, and while I was in the `.travis.yml` file I updated
our versions for Elixir and Erlang so we're up to the latest.