### PR TITLE
Add additional test case for `prime-factors`

### DIFF
--- a/exercises/prime-factors/example.exs
+++ b/exercises/prime-factors/example.exs
@@ -1,18 +1,16 @@
 defmodule PrimeFactors do
-  def factors_for(n) when n < 2, do: []
+  @spec factors_for(pos_integer) :: [pos_integer]
   def factors_for(number) do
-    case least_divisor(number) do
-      nil    -> [number]
-      factor -> [factor, factors_for(round(number/factor))]
-    end |> List.flatten
+    do_factors(number)
   end
 
-  defp least_divisor(number) do
-    number
-      |> factor_range
-      |> Stream.filter(&(rem(number, &1) == 0))
-      |> Enum.at(0)
-  end
-
-  defp factor_range(number), do: (2..round(number/2))
+  defp do_factors(_, i \\ 2, acc \\ [])
+  defp do_factors(1, _, acc),
+    do: Enum.reverse(acc)
+  defp do_factors(n, i, acc) when n < i * i,
+    do: Enum.reverse(acc, [n])
+  defp do_factors(n, i, acc) when rem(n, i) == 0,
+    do: do_factors(div(n, i), i, [i | acc])
+  defp do_factors(n, i, acc),
+    do: do_factors(n, i + 1, acc)
 end

--- a/exercises/prime-factors/prime_factors_test.exs
+++ b/exercises/prime-factors/prime_factors_test.exs
@@ -62,4 +62,14 @@ defmodule PrimeFactorsTest do
   test "93819012551" do
     assert PrimeFactors.factors_for(93819012551) == [11, 9539, 894119]
   end
+
+  @tag :pending
+  # @tag timeout: 2000
+  #
+  # The timeout tag above will set the below test to fail unless it completes
+  # in under two sconds. Uncomment it if you want to test the efficiency of your
+  # solution.
+  test "10000000055" do
+    assert PrimeFactors.factors_for(10000000055) == [5, 2000000011]
+  end
 end


### PR DESCRIPTION
This commit adds an additional test case for the `prime-factors` exercise. The
idea was to add in optional performance tests to see if your solution was
quick. I don't quite know what we're going to call "quick" for the purposes of
this test, but since the person who posted the issue said their initial
implementation took 44 seconds, I chose 20 seconds as a starting point.

This addresses Issue #206.