### PR TITLE
Removing trailing whitespace from kindergarten-garden

### DIFF
--- a/exercises/kindergarten-garden/example.exs
+++ b/exercises/kindergarten-garden/example.exs
@@ -47,7 +47,7 @@ defmodule Garden do
   defp add_to_map(map, current_name, letters) do
     letters = String.codepoints(letters)
     translated_list = Enum.map(letters, fn(letter) -> @letter_map[letter] end)
-    tuple = List.to_tuple(translated_list) 
+    tuple = List.to_tuple(translated_list)
     Map.put(map, current_name, tuple)
   end
 end

--- a/exercises/kindergarten-garden/garden_test.exs
+++ b/exercises/kindergarten-garden/garden_test.exs
@@ -10,7 +10,7 @@ defmodule GardenTest do
 
   test "gets the garden for Alice with just her plants" do
     garden_info = Garden.info("RC\nGG")
-    assert garden_info.alice == {:radishes, :clover, :grass, :grass} 
+    assert garden_info.alice == {:radishes, :clover, :grass, :grass}
   end
 
   @tag :pending


### PR DESCRIPTION
We added in the Travis failure for trailing whitespace at the same time as this
exercise, so this missed the CI failure before being merged into master. This
should resolve everything, though, and get us back to green.