### PR TITLE
Rewrite tests and example for CustomSet

### DIFF
--- a/exercises/custom-set/custom_set.exs
+++ b/exercises/custom-set/custom_set.exs
@@ -1,5 +1,43 @@
 defmodule CustomSet do
-  # This lets the compiler check that all Set callback functions have been
-  # implemented.
-  @behaviour Set
+  @opaque t :: %__MODULE__{map: map}
+
+  @spec new(Enum.t) :: t
+  def new(enumerable) do
+  end
+
+  @spec empty?(t) :: boolean
+  def empty?(custom_set) do
+  end
+
+  @spec contains?(t, any) :: boolean
+  def contains?(custom_set, element) do
+  end
+
+  @spec subset?(t, t) :: boolean
+  def subset?(custom_set_1, custom_set_2) do
+  end
+
+  @spec disjoint?(t, t) :: boolean
+  def disjoint?(custom_set_1, custom_set_2) do
+  end
+
+  @spec equal?(t, t) :: boolean
+  def equal?(custom_set_1, custom_set_2) do
+  end
+
+  @spec add(t, any) :: t
+  def add(custom_set, element) do
+  end
+
+  @spec intersection(t, t) :: t
+  def intersection(custom_set_1, custom_set_2) do
+  end
+
+  @spec difference(t, t) :: t
+  def difference(custom_set_1, custom_set_2) do
+  end
+
+  @spec union(t, t) :: t
+  def union(custom_set_1, custom_set_2) do
+  end
 end

--- a/exercises/custom-set/custom_set_test.exs
+++ b/exercises/custom-set/custom_set_test.exs
@@ -8,121 +8,288 @@ ExUnit.configure exclude: :pending, trace: true
 defmodule CustomSetTest do
   use ExUnit.Case
 
-  # Tip: to make your set work with the Set module be sure that your set value
-  # is a tuple with as first element `CustomSet`. A record with tag `CustomSet`
-  # will meet this requirement.
-
   # @tag :pending
-  test "delete" do
-    assert Set.equal?(Set.delete(CustomSet.new([3,2,1]), 2), CustomSet.new([1,3]))
-    assert Set.equal?(Set.delete(CustomSet.new([3,2,1]), 4), CustomSet.new([1,2,3]))
-    assert Set.equal?(Set.delete(CustomSet.new([3,2,1]), 2.0), CustomSet.new([1,2,3]))
+  describe "new" do
+    test "returns a CustomSet struct" do
+      assert CustomSet.new([]) == %CustomSet{}
+    end
+
+    test "removes duplicates in the given enumerable" do
+      actual = CustomSet.new([1, 1, 2, 3])
+      expected = CustomSet.new([1, 2, 3])
+      assert actual == expected
+    end
   end
 
   @tag :pending
-  test "difference" do
-    assert Set.equal?(
-      Set.difference(CustomSet.new([1,2,3]), CustomSet.new([2,4])),
-      CustomSet.new([1,3]))
-    assert Set.equal?(
-      Set.difference(CustomSet.new([1,2.0,3]), CustomSet.new([2,4])),
-      CustomSet.new([1,2.0,3]))
+  describe "empty?" do
+    test "sets with no elements are empty" do
+      custom_set = CustomSet.new([])
+      assert CustomSet.empty?(custom_set) == true
+    end
+
+    test "sets with elements are not empty" do
+      custom_set = CustomSet.new([1])
+      assert CustomSet.empty?(custom_set) == false
+    end
   end
 
   @tag :pending
-  test "disjoint?" do
-    assert Set.disjoint?(CustomSet.new([1,2]), CustomSet.new([3,4]))
-    refute Set.disjoint?(CustomSet.new([1,2]), CustomSet.new([2,3]))
-    assert Set.disjoint?(CustomSet.new([1.0,2.0]), CustomSet.new([2,3]))
-    assert Set.disjoint?(CustomSet.new, CustomSet.new)
+  describe "contains?" do
+    test "nothing is contained in an empty set" do
+      custom_set = CustomSet.new([])
+      assert CustomSet.contains?(custom_set, 1) == false
+    end
+
+    test "when the element is in the set" do
+      custom_set = CustomSet.new([1, 2, 3])
+      assert CustomSet.contains?(custom_set, 1) == true
+    end
+
+    test "when the element is not in the set" do
+      custom_set = CustomSet.new([1, 2, 3])
+      assert CustomSet.contains?(custom_set, 4) == false
+    end
   end
 
   @tag :pending
-  test "empty" do
-    assert Set.equal?(Set.empty(CustomSet.new([1,2])), CustomSet.new)
-    assert Set.equal?(Set.empty(CustomSet.new), CustomSet.new)
+  describe "subset?" do
+    test "empty set is a subset of another empty set" do
+      custom_set_1 = CustomSet.new([])
+      custom_set_2 = CustomSet.new([])
+      assert CustomSet.subset?(custom_set_1, custom_set_2) == true
+    end
+
+    test "empty set is a subset of non-empty set" do
+      custom_set_1 = CustomSet.new([])
+      custom_set_2 = CustomSet.new([1])
+      assert CustomSet.subset?(custom_set_1, custom_set_2) == true
+    end
+
+    test "non-empty set is not a subset of empty set" do
+      custom_set_1 = CustomSet.new([1])
+      custom_set_2 = CustomSet.new([])
+      assert CustomSet.subset?(custom_set_1, custom_set_2) == false
+    end
+
+    test "set is a subset of set with exact same elements" do
+      custom_set_1 = CustomSet.new([1, 2, 3])
+      custom_set_2 = CustomSet.new([1, 2, 3])
+      assert CustomSet.subset?(custom_set_1, custom_set_2) == true
+    end
+
+    test "set is a subset of larger set with same elements" do
+      custom_set_1 = CustomSet.new([1, 2, 3])
+      custom_set_2 = CustomSet.new([4, 1, 2, 3])
+      assert CustomSet.subset?(custom_set_1, custom_set_2) == true
+    end
+
+    test "set is not a subset of set that does not contain its elements" do
+      custom_set_1 = CustomSet.new([1, 2, 3])
+      custom_set_2 = CustomSet.new([4, 1, 3])
+      assert CustomSet.subset?(custom_set_1, custom_set_2) == false
+    end
   end
 
   @tag :pending
-  test "intersection" do
-    assert Set.equal?(
-      Set.intersection(CustomSet.new([:a, :b, :c]), CustomSet.new([:a, :c, :d])),
-      CustomSet.new([:a, :c]))
-    assert Set.equal?(
-      Set.intersection(CustomSet.new([1, 2, 3]), CustomSet.new([1.0, 2.0, 3])),
-      CustomSet.new([3]))
+  describe "disjoint?" do
+    test "the empty set is disjoint with itself" do
+      custom_set_1 = CustomSet.new([])
+      custom_set_2 = CustomSet.new([])
+      assert CustomSet.disjoint?(custom_set_1, custom_set_2) == true
+    end
+
+    test "empty set is disjoint with non-empty set" do
+      custom_set_1 = CustomSet.new([])
+      custom_set_2 = CustomSet.new([1])
+      assert CustomSet.disjoint?(custom_set_1, custom_set_2) == true
+    end
+
+    test "non-empty set is disjoint with empty set" do
+      custom_set_1 = CustomSet.new([1])
+      custom_set_2 = CustomSet.new([])
+      assert CustomSet.disjoint?(custom_set_1, custom_set_2) == true
+    end
+
+    test "sets are not disjoint if they share an element" do
+      custom_set_1 = CustomSet.new([1, 2])
+      custom_set_2 = CustomSet.new([2, 3])
+      assert CustomSet.disjoint?(custom_set_1, custom_set_2) == false
+    end
+
+    test "sets are disjoint if they share no elements" do
+      custom_set_1 = CustomSet.new([1, 2])
+      custom_set_2 = CustomSet.new([3, 4])
+      assert CustomSet.disjoint?(custom_set_1, custom_set_2) == true
+    end
   end
 
   @tag :pending
-  test "member?" do
-    assert Set.member?(CustomSet.new([1,2,3]), 2)
-    assert Set.member?(CustomSet.new(1..3), 2)
-    refute Set.member?(CustomSet.new(1..3), 2.0)
-    refute Set.member?(CustomSet.new(1..3), 4)
+  describe "equal?" do
+    test "empty sets are equal" do
+      custom_set_1 = CustomSet.new([])
+      custom_set_2 = CustomSet.new([])
+      assert CustomSet.equal?(custom_set_1, custom_set_2) == true
+    end
+
+    test "empty set is not equal to non-empty set" do
+      custom_set_1 = CustomSet.new([])
+      custom_set_2 = CustomSet.new([1, 2, 3])
+      assert CustomSet.equal?(custom_set_1, custom_set_2) == false
+    end
+
+    test "non-empty set is not equal to empty set" do
+      custom_set_1 = CustomSet.new([1, 2, 3])
+      custom_set_2 = CustomSet.new([])
+      assert CustomSet.equal?(custom_set_1, custom_set_2) == false
+    end
+
+    test "sets with the same elements are equal" do
+      custom_set_1 = CustomSet.new([1, 2])
+      custom_set_2 = CustomSet.new([2, 1])
+      assert CustomSet.equal?(custom_set_1, custom_set_2) == true
+    end
+
+    test "sets with different elements are not equal" do
+      custom_set_1 = CustomSet.new([1, 2, 3])
+      custom_set_2 = CustomSet.new([1, 2, 4])
+      assert CustomSet.equal?(custom_set_1, custom_set_2) == false
+    end
   end
 
   @tag :pending
-  test "put" do
-    assert Set.equal?(
-      Set.put(CustomSet.new([1,2,4]), 3),
-      CustomSet.new([1,2,3,4]))
-    assert Set.equal?(
-      Set.put(CustomSet.new([1,2,3]), 3),
-      CustomSet.new([1,2,3]))
-    assert Set.equal?(
-      Set.put(CustomSet.new([1,2,3]), 3.0),
-      CustomSet.new([1,2,3,3.0]))
+  describe "add" do
+    test "add to empty set" do
+      custom_set = CustomSet.new([])
+      actual = CustomSet.add(custom_set, 3)
+      expected = CustomSet.new([3])
+      assert CustomSet.equal?(actual, expected)
+    end
+
+    test "add to non-empty set" do
+      custom_set = CustomSet.new([1, 2, 4])
+      actual = CustomSet.add(custom_set, 3)
+      expected = CustomSet.new([1, 2, 3, 4])
+      assert CustomSet.equal?(actual, expected)
+    end
+
+    test "adding an existing element does not change the set" do
+      expected = CustomSet.new([1, 2, 3])
+      actual = CustomSet.add(expected, 3)
+      assert CustomSet.equal?(expected, actual)
+    end
   end
 
   @tag :pending
-  test "size" do
-    assert Set.size(CustomSet.new) == 0
-    assert Set.size(CustomSet.new([1,2,3])) == 3
-    assert Set.size(CustomSet.new([1,2,3,2])) == 3
+  describe "intersection" do
+    test "intersection of two empty sets is an empty set" do
+      custom_set_1 = CustomSet.new([])
+      custom_set_2 = CustomSet.new([])
+      actual = CustomSet.intersection(custom_set_1, custom_set_2)
+      expected = CustomSet.new([])
+      assert CustomSet.equal?(actual, expected)
+    end
+
+    test "intersection of an empty set and non-empty set is an empty set" do
+      custom_set_1 = CustomSet.new([])
+      custom_set_2 = CustomSet.new([3, 2, 5])
+      actual = CustomSet.intersection(custom_set_1, custom_set_2)
+      expected = CustomSet.new([])
+      assert CustomSet.equal?(actual, expected)
+    end
+
+    test "intersection of a non-empty set and an empty set is an empty set" do
+      custom_set_1 = CustomSet.new([1, 2, 3, 4])
+      custom_set_2 = CustomSet.new([])
+      actual = CustomSet.intersection(custom_set_1, custom_set_2)
+      expected = CustomSet.new([])
+      assert CustomSet.equal?(actual, expected)
+    end
+
+    test "intersection of two sets with no shared elements is an empty set" do
+      custom_set_1 = CustomSet.new([1, 2, 3])
+      custom_set_2 = CustomSet.new([4, 5, 6])
+      actual = CustomSet.intersection(custom_set_1, custom_set_2)
+      expected = CustomSet.new([])
+      assert CustomSet.equal?(actual, expected)
+    end
+
+    test "intersection of two sets with shared elements is a set of the shared elements" do
+      custom_set_1 = CustomSet.new([1, 2, 3, 4])
+      custom_set_2 = CustomSet.new([3, 2, 5])
+      actual = CustomSet.intersection(custom_set_1, custom_set_2)
+      expected = CustomSet.new([2, 3])
+      assert CustomSet.equal?(actual, expected)
+    end
   end
 
   @tag :pending
-  test "subset?" do
-    assert Set.subset?(CustomSet.new([1,2,3]), CustomSet.new([1,2,3]))
-    assert Set.subset?(CustomSet.new([1,2,3]), CustomSet.new([4,1,2,3]))
-    refute Set.subset?(CustomSet.new([1,2,3]), CustomSet.new([4,1,3]))
-    refute Set.subset?(CustomSet.new([1,2,3.0]), CustomSet.new([1,2,3,4]))
-    assert Set.subset?(CustomSet.new, CustomSet.new([4,1,3]))
-    assert Set.subset?(CustomSet.new, CustomSet.new)
+  describe "difference" do
+    test "difference of two empty sets is an empty set" do
+      custom_set_1 = CustomSet.new([])
+      custom_set_2 = CustomSet.new([])
+      actual = CustomSet.difference(custom_set_1, custom_set_2)
+      expected = CustomSet.new([])
+      assert CustomSet.equal?(actual, expected)
+    end
+
+    test "difference of empty set and non-empty set is an empty set" do
+      custom_set_1 = CustomSet.new([])
+      custom_set_2 = CustomSet.new([3, 2, 5])
+      actual = CustomSet.difference(custom_set_1, custom_set_2)
+      expected = CustomSet.new([])
+      assert CustomSet.equal?(actual, expected)
+    end
+
+    test "difference of a non-empty set and an empty set is the non-empty set" do
+      custom_set_1 = CustomSet.new([1, 2, 3, 4])
+      custom_set_2 = CustomSet.new([])
+      actual = CustomSet.difference(custom_set_1, custom_set_2)
+      expected = CustomSet.new([1, 2, 3, 4])
+      assert CustomSet.equal?(actual, expected)
+    end
+
+    test "difference of two non-empty sets is a set of elements that are only in the first set" do
+      custom_set_1 = CustomSet.new([3, 2, 1])
+      custom_set_2 = CustomSet.new([2, 4])
+      actual = CustomSet.difference(custom_set_1, custom_set_2)
+      expected = CustomSet.new([1, 3])
+      assert CustomSet.equal?(actual, expected)
+    end
   end
 
   @tag :pending
-  test "to_list" do
-    assert Enum.sort(Set.to_list(CustomSet.new)) == []
-    assert Enum.sort(Set.to_list(CustomSet.new([3,1,2]))) == [1,2,3]
-    assert Enum.sort(Set.to_list(CustomSet.new([3,1,2,1]))) == [1,2,3]
-  end
+  describe "union" do
+    test "union of empty sets is an empty set" do
+      custom_set_1 = CustomSet.new([])
+      custom_set_2 = CustomSet.new([])
+      actual = CustomSet.union(custom_set_1, custom_set_2)
+      expected = CustomSet.new([])
+      assert CustomSet.equal?(actual, expected)
+    end
 
-  @tag :pending
-  test "union" do
-    assert Set.equal?(
-      CustomSet.union(CustomSet.new([1,3]), CustomSet.new([2])),
-      CustomSet.new([3,2,1]))
-    assert Set.equal?(
-      CustomSet.union(CustomSet.new([1,3]), CustomSet.new([2,3.0])),
-      CustomSet.new([3.0,3,2,1]))
-    assert Set.equal?(
-      CustomSet.union(CustomSet.new([1,3]), CustomSet.new),
-      CustomSet.new([3,1]))
-    assert Set.equal?(
-      CustomSet.union(CustomSet.new, CustomSet.new([2])),
-      CustomSet.new([2]))
-    assert Set.equal?(
-      CustomSet.union(CustomSet.new, CustomSet.new),
-      CustomSet.new([]))
-  end
+    test "union of an empty set and non-empty set is the non-empty set" do
+      custom_set_1 = CustomSet.new([])
+      custom_set_2 = CustomSet.new([2])
+      actual = CustomSet.union(custom_set_1, custom_set_2)
+      expected = CustomSet.new([2])
+      assert CustomSet.equal?(actual, expected)
+    end
 
-  @tag :pending
-  test "inspect" do
-    assert inspect(CustomSet.new) == "%CustomSet{list: []}"
-    assert inspect(CustomSet.new([1,3,2])) == "%CustomSet{list: [1, 2, 3]}"
-    # Weird ordering due to how Elixir/Erlang considers binaries, numbers and
-    # atoms to be ordered.
-    assert inspect(CustomSet.new(["A",:b,?C])) == "%CustomSet{list: [67, :b, \"A\"]}"
+    test "union of a non-empty set and empty set is the non-empty set" do
+      custom_set_1 = CustomSet.new([1, 3])
+      custom_set_2 = CustomSet.new([])
+      actual = CustomSet.union(custom_set_1, custom_set_2)
+      expected = CustomSet.new([1, 3])
+      assert CustomSet.equal?(actual, expected)
+    end
+
+    test "union of non-empty sets contains all unique elements" do
+      custom_set_1 = CustomSet.new([1, 3])
+      custom_set_2 = CustomSet.new([2, 3])
+      actual = CustomSet.union(custom_set_1, custom_set_2)
+      expected = CustomSet.new([1, 2, 3])
+      assert CustomSet.equal?(actual, expected)
+    end
   end
 end


### PR DESCRIPTION
We have a lot of issues open around the `CustomSet` example. This PR rewrites
that to remove the deprecated `Set` module, and also updates it to use the
current tests listed in the `exercism/x-common` repo.

resolves #121 
resolves #180 
resolves #189 
resolves #198 
resolves #217 