### PR TITLE
Fix compiler warnings when running `mix test`

### DIFF
--- a/exercises/flatten-array/example.exs
+++ b/exercises/flatten-array/example.exs
@@ -1,13 +1,13 @@
-defmodule Flattener do
+defmodule FlattenArray do
   @doc """
     Accept a list and return the list flattened without nil values.
 
     ## Examples
 
-      iex> Flattener.flatten([1, [2], 3, nil])
+      iex> FlattenArray.flatten([1, [2], 3, nil])
       [1,2,3]
 
-      iex> Flattener.flatten([nil, nil])
+      iex> FlattenArray.flatten([nil, nil])
       []
 
   """

--- a/exercises/flatten-array/flatten_array.exs
+++ b/exercises/flatten-array/flatten_array.exs
@@ -1,13 +1,13 @@
-defmodule Flattener do
+defmodule FlattenArray do
   @doc """
     Accept a list and return the list flattened without nil values.
 
     ## Examples
 
-      iex> Flattener.flatten([1, [2], 3, nil])
+      iex> FlattenArray.flatten([1, [2], 3, nil])
       [1,2,3]
 
-      iex> Flattener.flatten([nil, nil])
+      iex> FlattenArray.flatten([nil, nil])
       []
 
   """

--- a/exercises/flatten-array/flatten_array_test.exs
+++ b/exercises/flatten-array/flatten_array_test.exs
@@ -5,35 +5,35 @@ end
 ExUnit.start
 ExUnit.configure exclude: :pending, trace: true
 
-defmodule ChangeTest do
+defmodule FlattenArrayTest do
   use ExUnit.Case
 
   test "returns original list if there is nothing to flatten" do
-    assert Flattener.flatten([1, 2, 3]) ==  [1, 2, 3]
+    assert FlattenArray.flatten([1, 2, 3]) ==  [1, 2, 3]
   end
 
   @tag :pending
   test "flattens an empty nested list" do
-    assert Flattener.flatten([[]]) ==  []
+    assert FlattenArray.flatten([[]]) ==  []
   end
 
   @tag :pending
   test "flattens a nested list" do
-    assert Flattener.flatten([1,[2,[3],4],5,[6,[7,8]]]) == [1, 2, 3, 4, 5, 6, 7, 8]
+    assert FlattenArray.flatten([1,[2,[3],4],5,[6,[7,8]]]) == [1, 2, 3, 4, 5, 6, 7, 8]
   end
 
   @tag :pending
   test "removes nil from list" do
-    assert Flattener.flatten([1, nil, 2]) ==  [1, 2]
+    assert FlattenArray.flatten([1, nil, 2]) ==  [1, 2]
   end
 
   @tag :pending
   test "removes nil from a nested list" do
-    assert Flattener.flatten([1, [2, nil, 4], 5]) ==  [1, 2, 4, 5]
+    assert FlattenArray.flatten([1, [2, nil, 4], 5]) ==  [1, 2, 4, 5]
   end
 
   @tag :pending
   test "returns an empty list if all values in nested list are nil" do
-    assert Flattener.flatten([nil, [nil], [nil, [nil]]]) ==  []
+    assert FlattenArray.flatten([nil, [nil], [nil, [nil]]]) ==  []
   end
 end

--- a/exercises/hamming/example.exs
+++ b/exercises/hamming/example.exs
@@ -1,10 +1,10 @@
-defmodule DNA do
+defmodule Hamming do
   @doc """
-  Returns number of differences between two strands of DNA, known as the Hamming Distance.
+  Returns number of differences between two strands of Hamming, known as the Hamming Distance.
 
   ## Examples
 
-  iex> DNA.hamming_distance('AAGTCATA', 'TAGCGATC')
+  iex> Hamming.hamming_distance('AAGTCATA', 'TAGCGATC')
   {:ok, 4}
   """
   def hamming_distance(strand1, strand2) when length(strand1) === length(strand2) do

--- a/exercises/hamming/hamming_test.exs
+++ b/exercises/hamming/hamming_test.exs
@@ -5,36 +5,36 @@ end
 ExUnit.start
 ExUnit.configure exclude: :pending, trace: true
 
-defmodule DNATest do
+defmodule HammingTest do
   use ExUnit.Case
 
   test "no difference between empty strands" do
-    assert DNA.hamming_distance('', '') == {:ok, 0}
+    assert Hamming.hamming_distance('', '') == {:ok, 0}
   end
 
   @tag :pending
   test "no difference between identical strands" do
-    assert DNA.hamming_distance('GGACTGA', 'GGACTGA') == {:ok, 0}
+    assert Hamming.hamming_distance('GGACTGA', 'GGACTGA') == {:ok, 0}
   end
 
   @tag :pending
   test "small hamming distance in middle somewhere" do
-    assert DNA.hamming_distance('GGACG', 'GGTCG') == {:ok, 1}
+    assert Hamming.hamming_distance('GGACG', 'GGTCG') == {:ok, 1}
   end
 
   @tag :pending
   test "distance with same nucleotides in different locations" do
-    assert DNA.hamming_distance('TAG', 'GAT') == {:ok, 2}
+    assert Hamming.hamming_distance('TAG', 'GAT') == {:ok, 2}
   end
 
   @tag :pending
   test "larger distance" do
-    assert DNA.hamming_distance('ACCAGGG', 'ACTATGG') == {:ok, 2}
+    assert Hamming.hamming_distance('ACCAGGG', 'ACTATGG') == {:ok, 2}
   end
 
   @tag :pending
   test "hamming distance is undefined for strands of different lengths" do
-    assert {:error, "Lists must be the same length."} = DNA.hamming_distance('AAAC', 'TAGGGGAGGCTAGCGGTAGGAC')
-    assert {:error, "Lists must be the same length."} = DNA.hamming_distance('GACTACGGACAGGACACC', 'GACATCGC')
+    assert {:error, "Lists must be the same length"} = Hamming.hamming_distance('AAAC', 'TAGGGGAGGCTAGCGGTAGGAC')
+    assert {:error, "Lists must be the same length"} = Hamming.hamming_distance('GACTACGGACAGGACACC', 'GACATCGC')
   end
 end

--- a/exercises/hexadecimal/hexadecimal_test.exs
+++ b/exercises/hexadecimal/hexadecimal_test.exs
@@ -5,7 +5,7 @@ end
 ExUnit.start
 ExUnit.configure exclude: :pending, trace: true
 
-defmodule ChangeTest do
+defmodule HexadecimalTest do
   use ExUnit.Case
 
   test "returns 1 when hex is 1" do

--- a/exercises/largest-series-product/example.exs
+++ b/exercises/largest-series-product/example.exs
@@ -1,8 +1,5 @@
 defmodule Series do
 
-  @doc """
-  Splits up the given string of numbers into an array of integers.
-  """
   @spec digits(String.t) :: [non_neg_integer]
   defp digits("") do
     []
@@ -14,9 +11,6 @@ defmodule Series do
     |> Enum.reverse
   end
 
-  @doc """
-  Generates sublists of a given size from a given string of numbers.
-  """
   @spec slices(String.t, non_neg_integer) :: [list(non_neg_integer)]
   defp slices(number_string, size) do
     digits = digits(number_string)

--- a/exercises/nucleotide-count/example.exs
+++ b/exercises/nucleotide-count/example.exs
@@ -1,15 +1,15 @@
-defmodule DNA do
+defmodule NucleotideCount do
   @nucleotides [?A, ?C, ?G, ?T]
 
   @doc """
-  Counts individual nucleotides in a DNA strand.
+  Counts individual nucleotides in a NucleotideCount strand.
 
   ## Examples
 
-  iex> DNA.count('AATAA', ?A)
+  iex> NucleotideCount.count('AATAA', ?A)
   4
 
-  iex> DNA.count('AATAA', ?T)
+  iex> NucleotideCount.count('AATAA', ?T)
   1
   """
 
@@ -24,7 +24,7 @@ defmodule DNA do
 
   ## Examples
 
-  iex> DNA.nucleotide_counts('AATAA')
+  iex> NucleotideCount.nucleotide_counts('AATAA')
   %{?A => 4, ?T => 1, ?C => 0, ?G => 0}
   """
 

--- a/exercises/nucleotide-count/nucleotide_count.exs
+++ b/exercises/nucleotide-count/nucleotide_count.exs
@@ -1,15 +1,15 @@
-defmodule DNA do
+defmodule NucleotideCount do
   @nucleotides [?A, ?C, ?G, ?T]
 
   @doc """
-  Counts individual nucleotides in a DNA strand.
+  Counts individual nucleotides in a NucleotideCount strand.
 
   ## Examples
 
-  iex> DNA.count('AATAA', ?A)
+  iex> NucleotideCount.count('AATAA', ?A)
   4
 
-  iex> DNA.count('AATAA', ?T)
+  iex> NucleotideCount.count('AATAA', ?T)
   1
   """
   @spec count([char], char) :: non_neg_integer
@@ -23,7 +23,7 @@ defmodule DNA do
 
   ## Examples
 
-  iex> DNA.histogram('AATAA')
+  iex> NucleotideCount.histogram('AATAA')
   %{?A => 4, ?T => 1, ?C => 0, ?G => 0}
   """
   @spec histogram([char]) :: map

--- a/exercises/nucleotide-count/nucleotide_count_test.exs
+++ b/exercises/nucleotide-count/nucleotide_count_test.exs
@@ -5,61 +5,61 @@ end
 ExUnit.start
 ExUnit.configure exclude: :pending, trace: true
 
-defmodule DNATest do
+defmodule NucleotideCountTest do
   use ExUnit.Case
 
   # @tag :pending
   test "empty dna string has no adenosine" do
-    assert DNA.count('', ?A) == 0
+    assert NucleotideCount.count('', ?A) == 0
   end
 
   @tag :pending
   test "repetitive cytidine gets counted" do
-    assert DNA.count('CCCCC', ?C) == 5
+    assert NucleotideCount.count('CCCCC', ?C) == 5
   end
 
   @tag :pending
   test "counts only thymidine" do
-    assert DNA.count('GGGGGTAACCCGG', ?T) == 1
+    assert NucleotideCount.count('GGGGGTAACCCGG', ?T) == 1
   end
 
   @tag :pending
   test "empty dna string has no nucleotides" do
     expected = %{?A => 0, ?T => 0, ?C => 0, ?G => 0}
-    assert DNA.histogram('') == expected
+    assert NucleotideCount.histogram('') == expected
   end
 
   @tag :pending
   test "repetitive sequence has only guanosine" do
     expected = %{?A => 0, ?T => 0, ?C => 0, ?G => 8}
-    assert DNA.histogram('GGGGGGGG') == expected
+    assert NucleotideCount.histogram('GGGGGGGG') == expected
   end
 
   @tag :pending
   test "counts all nucleotides" do
     s = 'AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC'
     expected = %{?A => 20, ?T => 21, ?C => 12, ?G => 17}
-    assert DNA.histogram(s) == expected
+    assert NucleotideCount.histogram(s) == expected
   end
 
   @tag :pending
   test "histogram validates the strand" do
     assert_raise ArgumentError, fn ->
-      DNA.histogram('JOHNNYAPPLESEED')
+      NucleotideCount.histogram('JOHNNYAPPLESEED')
     end
   end
 
   @tag :pending
   test "count validates the nucleotide" do
     assert_raise ArgumentError, fn ->
-      DNA.count('', ?U)
+      NucleotideCount.count('', ?U)
     end
   end
 
   @tag :pending
   test "count validates the strand" do
     assert_raise ArgumentError, fn ->
-      DNA.count('JOHNNYAPPLESEED', ?A)
+      NucleotideCount.count('JOHNNYAPPLESEED', ?A)
     end
   end
 end

--- a/exercises/rna-transcription/example.exs
+++ b/exercises/rna-transcription/example.exs
@@ -1,10 +1,10 @@
-defmodule DNA do
+defmodule RNATranscription do
   @doc """
-  Transcribes a character list representing DNA nucleotides to RNA
+  Transcribes a character list representing RNATranscription nucleotides to RNA
 
   ## Examples
 
-  iex> DNA.to_rna('ACTG')
+  iex> RNATranscription.to_rna('ACTG')
   'UGAC'
   """
   def to_rna(dna) do

--- a/exercises/rna-transcription/rna_transcription.exs
+++ b/exercises/rna-transcription/rna_transcription.exs
@@ -1,10 +1,10 @@
-defmodule DNA do
+defmodule RNATranscription do
   @doc """
   Transcribes a character list representing DNA nucleotides to RNA
 
   ## Examples
 
-  iex> DNA.to_rna('ACTG')
+  iex> RNATranscription.to_rna('ACTG')
   'UGAC'
   """
   @spec to_rna([char]) :: [char]

--- a/exercises/rna-transcription/rna_transcription_test.exs
+++ b/exercises/rna-transcription/rna_transcription_test.exs
@@ -5,31 +5,31 @@ end
 ExUnit.start
 ExUnit.configure exclude: :pending, trace: true
 
-defmodule DNATest do
+defmodule RNATranscriptionTest do
   use ExUnit.Case
 
   # @tag :pending
   test "transcribes guanine to cytosine" do
-    assert DNA.to_rna('G') == 'C'
+    assert RNATranscription.to_rna('G') == 'C'
   end
 
   @tag :pending
   test "transcribes cytosine to guanine" do
-    assert DNA.to_rna('C') == 'G'
+    assert RNATranscription.to_rna('C') == 'G'
   end
 
   @tag :pending
   test "transcribes thymidine to adenine" do
-    assert DNA.to_rna('T') == 'A'
+    assert RNATranscription.to_rna('T') == 'A'
   end
 
   @tag :pending
   test "transcribes adenine to uracil" do
-    assert DNA.to_rna('A') == 'U'
+    assert RNATranscription.to_rna('A') == 'U'
   end
 
   @tag :pending
   test "it transcribes all dna nucleotides to rna equivalents" do
-    assert DNA.to_rna('ACGTGGTCTTAA') == 'UGCACCAGAAUU'
+    assert RNATranscription.to_rna('ACGTGGTCTTAA') == 'UGCACCAGAAUU'
   end
 end

--- a/exercises/zipper/example.exs
+++ b/exercises/zipper/example.exs
@@ -1,4 +1,5 @@
 defmodule BinTree do
+  import Inspect.Algebra
   @moduledoc """
   A node in a binary tree.
 
@@ -8,6 +9,17 @@ defmodule BinTree do
   """
   @type t :: %BinTree{ value: any, left: BinTree.t | nil, right: BinTree.t | nil }
   defstruct value: nil, left: nil, right: nil
+
+  # A custom inspect instance purely for the tests, this makes error messages
+  # much more readable.
+  #
+  # BT[value: 3, left: BT[value: 5, right: BT[value: 6]]] becomes (3:(5::(6::)):)
+  def inspect(%BinTree{value: v, left: l, right: r}, opts) do
+    concat ["(", to_doc(v, opts),
+            ":", (if l, do: to_doc(l, opts), else: ""),
+            ":", (if r, do: to_doc(r, opts), else: ""),
+            ")"]
+  end
 end
 
 defmodule BinTree.Zipper do

--- a/exercises/zipper/zipper.exs
+++ b/exercises/zipper/zipper.exs
@@ -1,4 +1,5 @@
 defmodule BinTree do
+  import Inspect.Algebra
   @moduledoc """
   A node in a binary tree.
 
@@ -8,6 +9,17 @@ defmodule BinTree do
   """
   @type t :: %BinTree{ value: any, left: BinTree.t | nil, right: BinTree.t | nil }
   defstruct value: nil, left: nil, right: nil
+
+  # A custom inspect instance purely for the tests, this makes error messages
+  # much more readable.
+  #
+  # BT[value: 3, left: BT[value: 5, right: BT[value: 6]]] becomes (3:(5::(6::)):)
+  def inspect(%BinTree{value: v, left: l, right: r}, opts) do
+    concat ["(", to_doc(v, opts),
+            ":", (if l, do: to_doc(l, opts), else: ""),
+            ":", (if r, do: to_doc(r, opts), else: ""),
+            ")"]
+  end
 end
 
 defmodule Zipper do

--- a/exercises/zipper/zipper_test.exs
+++ b/exercises/zipper/zipper_test.exs
@@ -8,22 +8,6 @@ ExUnit.configure exclude: :pending, trace: true
 defmodule ZipperTest do
   alias BinTree, as: BT
   import Zipper
-
-  # A custom inspect instance purely for the tests, this makes error messages
-  # much more readable.
-  #
-  # BT[value: 3, left: BT[value: 5, right: BT[value: 6]]] becomes (3:(5::(6::)):)
-  defimpl Inspect, for: BT do
-    import Inspect.Algebra
-
-    def inspect(%BinTree{value: v, left: l, right: r}, opts) do
-      concat ["(", to_doc(v, opts),
-              ":", (if l, do: to_doc(l, opts), else: ""),
-              ":", (if r, do: to_doc(r, opts), else: ""),
-              ")"]
-    end
-  end
-
   use ExUnit.Case
 
   defp bt(value, left, right), do: %BT{value: value, left: left, right: right}


### PR DESCRIPTION
When we ran `mix test` we were getting several compiler warnings. Here's the
ouput that we got before this PR:

```
warning: behaviour Set undefined
  exercises/custom-set/example.exs:1

warning: the Inspect protocol has already been consolidated, an implementation for CustomSet has no effect
  exercises/custom-set/example.exs:126

warning: function digits/1 is private, @doc's are always discarded for private functions
  exercises/largest-series-product/example.exs:3

warning: function slices/2 is private, @doc's are always discarded for private functions
  exercises/largest-series-product/example.exs:17

warning: redefining module DNA (current version defined in memory)
  exercises/nucleotide-count/example.exs:1

warning: redefining module DNA (current version defined in memory)
  exercises/rna-transcription/example.exs:1

Including tags: [:pending]

warning: redefining module ChangeTest (current version defined in memory)
  exercises/flatten-array/flatten_array_test.exs:8

warning: redefining module ChangeTest (current version defined in memory)
  exercises/hexadecimal/hexadecimal_test.exs:8

warning: redefining module DNATest (current version defined in memory)
  exercises/nucleotide-count/nucleotide_count_test.exs:8

warning: redefining module DNATest (current version defined in memory)
  exercises/rna-transcription/rna_transcription_test.exs:8

warning: the Inspect protocol has already been consolidated, an implementation for BinTree has no effect
  exercises/zipper/zipper_test.exs:16
```

I addressed all of the warnings except those for `CustomSet` since those
warnings are taken care of in #226. Many of them were naming issues for
modules, and funny enough this fix of the compiler warnings pointed out that we
had a typo in a test that should have failed but wasn't failing! I've also
fixed that typo.