### PR TITLE
Change build to fail on compile warnings

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -16,4 +16,8 @@ defmodule ExercismTestRunner.Mixfile do
   defp deps do
     [{:poison, "~> 1.4.0"}]
   end
+
+  defp aliases do
+    ["compile": ["compile --warnings-as-errors"]]
+  end
 end


### PR DESCRIPTION
We had accumulated several compiler warnings throughout this project, and in
this PR I'm adding some configuration that will fail the CI build if there are
any compiler warnings by turning them into errors thanks to the
`--warnings-as-errors` flag.