### PR TITLE
Update tests and example for NucleotideCount

### DIFF
--- a/exercises/nucleotide-count/nucleotide_count_test.exs
+++ b/exercises/nucleotide-count/nucleotide_count_test.exs
@@ -41,25 +41,4 @@ defmodule NucleotideCountTest do
     expected = %{?A => 20, ?T => 21, ?C => 12, ?G => 17}
     assert NucleotideCount.histogram(s) == expected
   end
-
-  @tag :pending
-  test "histogram validates the strand" do
-    assert_raise ArgumentError, fn ->
-      NucleotideCount.histogram('JOHNNYAPPLESEED')
-    end
-  end
-
-  @tag :pending
-  test "count validates the nucleotide" do
-    assert_raise ArgumentError, fn ->
-      NucleotideCount.count('', ?U)
-    end
-  end
-
-  @tag :pending
-  test "count validates the strand" do
-    assert_raise ArgumentError, fn ->
-      NucleotideCount.count('JOHNNYAPPLESEED', ?A)
-    end
-  end
 end


### PR DESCRIPTION
There was a good point raised about some conventions in Elixir around raising
errors vs. returning tuples with error messages, so we've made some revisions
to the tests and example implementation for this exercise. We decided that
since there are examples of raising exceptions in the Elixir standard library,
that it wouldn't be a bad thing to include that functionality, but that we'd
_also_ include the more common pattern of returing tuples with error messages.

Closes #224 