### PR TITLE
Fix indentation and compiler warnings

### DIFF
--- a/exercises/grade-school/grade_school_test.exs
+++ b/exercises/grade-school/grade_school_test.exs
@@ -8,51 +8,51 @@ ExUnit.configure exclude: :pending, trace: true
 defmodule SchoolTest do
   use ExUnit.Case
 
-  def db, do: %{}
+  @db %{}
 
   test "add student" do
-    actual = School.add(db, "Aimee", 2)
+    actual = School.add(@db, "Aimee", 2)
     assert actual == %{2 =>["Aimee"]}
   end
 
   @tag :pending
   test "add more students in same class" do
-    actual = db
-     |> School.add("James", 2)
-     |> School.add("Blair", 2)
-     |> School.add("Paul", 2)
+    actual = @db
+    |> School.add("James", 2)
+    |> School.add("Blair", 2)
+    |> School.add("Paul", 2)
 
     assert Enum.sort(actual[2]) == ["Blair", "James", "Paul"]
   end
 
   @tag :pending
   test "add students to different grades" do
-    actual = db
-     |> School.add("Chelsea", 3)
-     |> School.add("Logan", 7)
+    actual = @db
+    |> School.add("Chelsea", 3)
+    |> School.add("Logan", 7)
 
     assert actual == %{3 => ["Chelsea"], 7 => ["Logan"]}
   end
 
   @tag :pending
   test "get students in a grade" do
-    actual = db
-     |> School.add("Bradley", 5)
-     |> School.add("Franklin", 5)
-     |> School.add("Jeff", 1)
-     |> School.grade(5)
+    actual = @db
+    |> School.add("Bradley", 5)
+    |> School.add("Franklin", 5)
+    |> School.add("Jeff", 1)
+    |> School.grade(5)
 
     assert Enum.sort(actual) == ["Bradley", "Franklin"]
   end
 
   @tag :pending
   test "get students in a non existent grade" do
-    assert [] == School.grade(db, 1)
+    assert [] == School.grade(@db, 1)
   end
 
   @tag :pending
   test "sort school by grade and by student name" do
-    actual = db
+    actual = @db
     |> School.add("Bart", 4)
     |> School.add("Jennifer", 4)
     |> School.add("Christopher", 4)


### PR DESCRIPTION
```
warning: variable "db" does not exist and is being expanded to "db()", please use parentheses to remove the ambiguity or change the variable name
  exercises/grade-school/grade_school_test.exs:14

warning: variable "db" does not exist and is being expanded to "db()", please use parentheses to remove the ambiguity or change the variable name
  exercises/grade-school/grade_school_test.exs:20

warning: variable "db" does not exist and is being expanded to "db()", please use parentheses to remove the ambiguity or change the variable name
  exercises/grade-school/grade_school_test.exs:30

warning: variable "db" does not exist and is being expanded to "db()", please use parentheses to remove the ambiguity or change the variable name
  exercises/grade-school/grade_school_test.exs:39

warning: variable "db" does not exist and is being expanded to "db()", please use parentheses to remove the ambiguity or change the variable name
  exercises/grade-school/grade_school_test.exs:50

warning: variable "db" does not exist and is being expanded to "db()", please use parentheses to remove the ambiguity or change the variable name
  exercises/grade-school/grade_school_test.exs:55
```