### PR TITLE
Fix typo in module name for hamming distance exercise

### DIFF
--- a/exercises/hamming/hamming.exs
+++ b/exercises/hamming/hamming.exs
@@ -1,4 +1,4 @@
-defmodule DNA do
+defmodule Hamming do
   @doc """
   Returns number of differences between two strands of DNA, known as the Hamming Distance.
 


### PR DESCRIPTION
There is a typo in the module name for the hamming distance exercise and this PR fixes it