### PR TITLE
Fix path to rna_transcription.exs

### DIFF
--- a/exercises/rna-transcription/rna_transcription_test.exs
+++ b/exercises/rna-transcription/rna_transcription_test.exs
@@ -1,5 +1,5 @@
 if !System.get_env("EXERCISM_TEST_EXAMPLES") do
-  Code.load_file("dna.exs", __DIR__)
+  Code.load_file("rna_transcription.exs", __DIR__)
 end
 
 ExUnit.start


### PR DESCRIPTION
It seems that test file attempts to load a file by wrong name.