### PR TITLE
Add new test to change task and adjusted solution

### DIFF
--- a/exercises/change/change_test.exs
+++ b/exercises/change/change_test.exs
@@ -30,6 +30,12 @@ defmodule ChangeTest do
   end
 
   @tag :pending
+  test "generates change using only small coins when it is not possible to combine them with larger coins" do
+    change = %{3 => 34, 100 => 0}
+    assert Change.generate(102, [3, 100]) == {:ok, change}
+  end
+
+  @tag :pending
   test "generates the same change given any coin order" do
     change = %{1 => 3, 5 => 1, 10 => 1}
     assert Change.generate(18, [1, 5, 10]) == {:ok, change}


### PR DESCRIPTION
There is a missing case when the amount could be changed by the coins with small value and couldn't be changed by coins with higher value.

Since solutions of most people just return `:error` is this case, i decided to add a testcase and adjust the solution. Here is a case:

```elixir
iex(2)> Change.generate(102, [3, 100])
{:ok, %{3 => 34, 100 => 0}}
```