### PR TITLE
Add dialyzer to ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,7 @@ script:
 - EXERCISM_TEST_EXAMPLES=true elixirc --warnings-as-errors **/example.exs **/*_test.exs -o ./tmp > /dev/null
 - rm -rf ./tmp
 
+- dialyzer --no_check_plt --plt $PLT_LOCATION
+
 - "! git grep ' $' -- \\*.exs | grep -v -e 'exercises/diamond/diamond_test.exs'"
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script:
 - EXERCISM_TEST_EXAMPLES=true elixirc --warnings-as-errors **/example.exs **/*_test.exs -o ./tmp > /dev/null
 - rm -rf ./tmp
 
-- dialyzer --no_check_plt --plt $PLT_LOCATION
+- bin/dialyzer_check.sh
 
 - "! git grep ' $' -- \\*.exs | grep -v -e 'exercises/diamond/diamond_test.exs'"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,5 @@ script:
 - dialyzer --no_check_plt --plt $PLT_LOCATION
 
 - "! git grep ' $' -- \\*.exs | grep -v -e 'exercises/diamond/diamond_test.exs'"
+
 sudo: false

--- a/bin/dialyzer_check.sh
+++ b/bin/dialyzer_check.sh
@@ -1,0 +1,28 @@
+mkdir -p ./tmp/src
+mkdir ./tmp/build
+
+
+for example_file in exercises/**/example.exs
+do
+  exercise_dir=$(dirname $example_file)
+  exercise=$(basename $exercise_dir)
+  cp "$exercise_dir/example.exs" "./tmp/src/$exercise.exs"
+done
+
+elixirc -o ./tmp/build ./tmp/src/*.exs
+
+if [ $CI ]; then
+    export PLT_FILENAME=elixir-${TRAVIS_ELIXIR_VERSION:=1.3.2}_${TRAVIS_OTP_RELEASE:=19.0}.plt
+    export PLT_LOCATION=./tmp/$PLT_FILENAME
+    wget -O $PLT_LOCATION https://github.com/danielberkompas/travis_elixir_plts/blob/master/elixir-${TRAVIS_ELIXIR_VERSION}_${TRAVIS_OTP_RELEASE}.plt?raw=true
+
+    dialyzer --no_check_plt --plt $PLT_LOCATION --no_native ./tmp/build;
+    RESULT=$?
+else
+    dialyzer ./tmp/build;
+    RESULT=$?
+fi
+
+rm -rf ./tmp
+
+exit $RESULT

--- a/exercises/bank-account/example.exs
+++ b/exercises/bank-account/example.exs
@@ -43,7 +43,7 @@ defmodule BankAccount do
   @doc """
   Close the bank. Makes the account unavailable.
   """
-  @spec close_bank(account) :: none
+  @spec close_bank(account) :: any
   def close_bank(account) do
     :gen_server.call(account, :close)
   end

--- a/exercises/clock/example.exs
+++ b/exercises/clock/example.exs
@@ -1,5 +1,7 @@
 defmodule Clock do
   defstruct hour: 0, minute: 0
+  @type t :: %Clock{hour: integer, minute: integer}
+  @type t(hour, minute) :: %Clock{hour: hour, minute: minute}
 
   @doc """
   Returns a string representation of a clock:
@@ -7,7 +9,7 @@ defmodule Clock do
       iex> Clock.new(8, 9) |> to_string
       "08:09"
   """
-  @spec new(integer, integer) :: Clock
+  @spec new(integer, integer) :: Clock.t
   def new(hour, minute) do
     rollover(%Clock{hour: hour, minute: minute})
   end
@@ -18,7 +20,7 @@ defmodule Clock do
       iex> Clock.new(10, 0) |> Clock.add(3) |> to_string
       "10:03"
   """
-  @spec add(Clock, integer) :: Clock
+  @spec add(Clock.t, integer) :: Clock.t
   def add(%Clock{hour: hour, minute: minute}, add_minute) do
     new(hour, minute + add_minute)
   end

--- a/exercises/prime-factors/example.exs
+++ b/exercises/prime-factors/example.exs
@@ -1,10 +1,9 @@
 defmodule PrimeFactors do
   @spec factors_for(pos_integer) :: [pos_integer]
   def factors_for(number) do
-    do_factors(number)
+    do_factors(number, 2, [])
   end
 
-  defp do_factors(_, i \\ 2, acc \\ [])
   defp do_factors(1, _, acc),
     do: Enum.reverse(acc)
   defp do_factors(n, i, acc) when n < i * i,

--- a/exercises/robot-simulator/example.exs
+++ b/exercises/robot-simulator/example.exs
@@ -27,15 +27,14 @@ defmodule RobotSimulator do
   def direction(%RobotSimulator{direction: dir}), do: dir
 
   defp orient(%RobotSimulator{} = robot, direction) when direction in @valid_directions do
-    %RobotSimulator{ robot | direction: direction }
+    %{ robot | direction: direction }
   end
   defp orient({ :error, _ } = error, _), do: error
   defp orient(_, _), do: { :error, "invalid direction" }
 
   defp place(%RobotSimulator{} = robot, { x, y } = position) when is_integer(x) and is_integer(y) do
-    %RobotSimulator{ robot | position: position }
+    %{ robot | position: position }
   end
-  defp place({ :error, _ } = error, _), do: error
   defp place(_, _), do: { :error, "invalid position" }
 
   defp move("R", %RobotSimulator{ direction: direction } = robot), do: robot |> orient(direction |> rotate_right)


### PR DESCRIPTION
@devonestes I think you were very close on this. I have built upon your fine work.

The biggest problem is that out of the box mix is not going to compile `.exs` files to `.beam` files that can be analyzed by dialyzer. We can force that with `elixirc`. 

The next issue is that all the files we want to analyze are called `example.exs` which does not give the best feedback as you can see in this build https://travis-ci.org/parkerl/xelixir/builds/157473389 I've done some shell scripting here to help with that. 

There are at least two issues left.

First, I have hard coded this to the 1.3.0 PLT version which seems to work on Travis but not for me locally. 

Second, this is a bit rough to run locally when the PLT is not hard coded as you have to set the Travis specific environment variables. We should be able to let contributors run this as smoothly as possible on their PRs.

P.S. There was a great Dialyzer talk at ElixirConf. I recommend a watch when the vids come out.