### PR TITLE
Fail CI on script compilation warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,11 @@ script:
 - bin/configlet .
 - mix deps.get
 - mix test
+
+# fail if there are any compiler warnings
+- mkdir ./tmp
+- EXERCISM_TEST_EXAMPLES=true elixirc --warnings-as-errors **/example.exs **/*_test.exs -o ./tmp > /dev/null
+- rm -rf ./tmp
+
 - "! git grep ' $' -- \\*.exs | grep -v -e 'exercises/diamond/diamond_test.exs'"
 sudo: false

--- a/mix.exs
+++ b/mix.exs
@@ -16,8 +16,4 @@ defmodule ExercismTestRunner.Mixfile do
   defp deps do
     [{:poison, "~> 1.4.0"}]
   end
-
-  defp aliases do
-    ["compile": ["compile --warnings-as-errors"]]
-  end
 end


### PR DESCRIPTION
When we run any mix test we are currently getting

```
warning: function aliases/0 is unused
  mix.exs:20
```

While investigating that, I discovered that the build was not actually failing on compiler warnings as we thought. This is primarily due to our files being `.exs` and therefore compiled just in time. The `--warnings-as-errors` seems to be ignored by mix. This adds a step to CI that will fail as expected. I'm not sure if this is the best solution but it works until we have a better one.