### PR TITLE
Use nested accumulate instead of recursive

### DIFF
--- a/exercises/accumulate/accumulate_test.exs
+++ b/exercises/accumulate/accumulate_test.exs
@@ -32,10 +32,10 @@ defmodule AccumulateTest do
   end
 
   @tag :pending
-  test "accumulate recursively" do
+  test "nested accumulate" do
     chars = ~w(a b c)
     nums  = ~w(1 2 3)
-    fun = fn(c) -> for num <- nums, do: c <> num end
+    fun = fn(c) -> Accumulate.accumulate(nums, &(c <> &1)) end
     expected = [["a1", "a2", "a3"], ["b1", "b2", "b3"], ["c1", "c2", "c3"]]
     assert Accumulate.accumulate(chars, fun) == expected
   end


### PR DESCRIPTION
Fixes #216

Recursive `accumulate` was not actually recursive.
Hence renamed the test description to use `nested` instead and change
test to use `accumulate` over 2 lists.