### PR TITLE
Point the test file to the app file

### DIFF
--- a/exercises/flatten-array/flatten_array_test.exs
+++ b/exercises/flatten-array/flatten_array_test.exs
@@ -1,5 +1,5 @@
 if !System.get_env("EXERCISM_TEST_EXAMPLES") do
-  Code.load_file("flatten_array.exs")
+  Code.load_file("flatten_array.exs", __DIR__)
 end
 
 ExUnit.start


### PR DESCRIPTION
With this change, compiling the test with `elixir` loads
`flatten_array.exs` from the same directory as the test, rather than the
root directory.