### PR TITLE
Binary search on tuple input

### DIFF
--- a/exercises/binary-search/binary_search.exs
+++ b/exercises/binary-search/binary_search.exs
@@ -1,24 +1,24 @@
 defmodule BinarySearch do
   @doc """
-    Searches for a key in the list using the binary search algorithm.
-    It returns :not_found if the key is not in the list.
-    Otherwise returns the tuple {:ok, index}.
+    Searches for a key in the tuple using the binary search algorithm.
+    It returns :not_found if the key is not in the tuple.
+    Otherwise returns {:ok, index}.
 
     ## Examples
 
-      iex> BinarySearch.search([], 2)
+      iex> BinarySearch.search({}, 2)
       :not_found
 
-      iex> BinarySearch.search([1, 3, 5], 2)
+      iex> BinarySearch.search({1, 3, 5}, 2)
       :not_found
 
-      iex> BinarySearch.search([1, 3, 5], 5)
+      iex> BinarySearch.search({1, 3, 5}, 5)
       {:ok, 2}
 
   """
 
-  @spec search(Enumerable.t, integer) :: {:ok, integer} | :not_found
-  def search(list, key) do
+  @spec search(tuple, integer) :: {:ok, integer} | :not_found
+  def search(numbers, key) do
 
   end
 end

--- a/exercises/binary-search/binary_search_test.exs
+++ b/exercises/binary-search/binary_search_test.exs
@@ -8,46 +8,39 @@ ExUnit.configure exclude: :pending, trace: true
 defmodule BinarySearchTest do
   use ExUnit.Case
 
-  test "returns :not_found on empty list" do
-    assert BinarySearch.search([], 2) == :not_found
+  test "returns :not_found on empty tuple" do
+    assert BinarySearch.search({}, 2) == :not_found
   end
 
   @tag :pending
-  test "raises ArgumentError for unsorted list" do
-    assert_raise ArgumentError, "expected list to be sorted", fn ->
-      BinarySearch.search([3, 2, 1], 2)
-    end
+  test "returns :not_found when key is not in the tuple" do
+    assert BinarySearch.search({2, 4, 6}, 3) == :not_found
   end
 
   @tag :pending
-  test "returns :not_found when key is not in the list" do
-    assert BinarySearch.search([2, 4, 6], 3) == :not_found
+  test "finds key in a tuple with a single item" do
+    assert BinarySearch.search({3}, 3) == {:ok, 0}
   end
 
   @tag :pending
-  test "finds key in a list with a single item" do
-    assert BinarySearch.search([3], 3) == {:ok, 0}
+  test "finds key when it is the first element in tuple" do
+    assert BinarySearch.search({1, 2, 4, 5, 6}, 1) == {:ok, 0}
   end
 
   @tag :pending
-  test "finds key when it is the first element in list" do
-    assert BinarySearch.search([1, 2, 4, 5, 6], 1) == {:ok, 0}
+  test "finds key when it is in the middle of the tuple" do
+    assert BinarySearch.search({1, 2, 4, 5, 6}, 4) == {:ok, 2}
   end
 
   @tag :pending
-  test "finds key when it is in the middle of the list" do
-    assert BinarySearch.search([1, 2, 4, 5, 6], 4) == {:ok, 2}
+  test "finds key when it is the last element in tuple" do
+    assert BinarySearch.search({1, 2, 4, 5, 6}, 6) == {:ok, 4}
   end
 
   @tag :pending
-  test "finds key when it is the last element in list" do
-    assert BinarySearch.search([1, 2, 4, 5, 6], 6) == {:ok, 4}
-  end
-
-  @tag :pending
-  test "finds key in a list with an even number of elements" do
-    list = [1, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377]
-    assert BinarySearch.search(list, 21) == {:ok, 5}
-    assert BinarySearch.search(list, 34) == {:ok, 6}
+  test "finds key in a tuple with an even number of elements" do
+    tuple = {1, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377}
+    assert BinarySearch.search(tuple, 21) == {:ok, 5}
+    assert BinarySearch.search(tuple, 34) == {:ok, 6}
   end
 end

--- a/exercises/binary-search/example.exs
+++ b/exercises/binary-search/example.exs
@@ -17,24 +17,20 @@ defmodule BinarySearch do
 
   """
 
-  @spec search(Enumerable.t, integer) :: {:ok, integer} | :not_found
-  def search([], _key), do: :not_found
-  def search(list, key) do
-    if Enum.sort(list) != list do
-      raise ArgumentError, "expected list to be sorted"
-    end
-
-    do_search(list, key, 0, length(list) - 1)
+  @spec search(tuple, integer) :: {:ok, integer} | :not_found
+  def search({}, _key), do: :not_found
+  def search(numbers, key) do
+    do_search(numbers, key, 0, tuple_size(numbers) - 1)
   end
 
-  defp do_search(_list, _key, low, high) when high < low, do: :not_found
-  defp do_search(list, key, low, high) do
+  defp do_search(_numbers, _key, low, high) when high < low, do: :not_found
+  defp do_search(numbers, key, low, high) do
     middle = div(low + high, 2)
-    middle_value = Enum.at(list, middle)
+    middle_value = elem(numbers, middle)
 
     cond do
-      key < middle_value -> do_search(list, key, low, middle - 1)
-      key > middle_value -> do_search(list, key, middle + 1, high)
+      key < middle_value -> do_search(numbers, key, low, middle - 1)
+      key > middle_value -> do_search(numbers, key, middle + 1, high)
       true               -> {:ok, middle}
     end
   end


### PR DESCRIPTION
A linked list is a poor data structure for binary search, as pointed out in #176. To do binary search in O(log n) time (which is the whole point of binary search), you need constant time access to the middle element.

To avoid teaching an anti-pattern, let's use tuples as input.

I've removed the test case and behaviour of checking that the input is sorted, raising ArgumentError otherwise. The example implementation compares the list to a sorted list, using `Enum.sort/1` in O(n log n) time. Adding to this, tuples aren't Enumerable, so I would have to convert to a list – O(n), I'd expect. Both steps blows O(log n) out of the water

It's conceptually better to have the user of BinarySearch ensure that the inputs are sorted. I think again it would be an anti-pattern to build checks into a binary search that sabotages the performance for valid input. Also, this check isn't essential to the algorithm this exercise teaches.