### PR TITLE
Revert "Replace :pending test tag with idiomatic :skip tag"

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The example solution should be named `example.exs`.
 
 - Use typespecs in the example and template files as described [here](http://elixir-lang.org/getting-started/typespecs-and-behaviours.html).
 
-- Each test file should have code like the following at the top of the file. This allows the tests to be run on CI and configures tests to be skipped with the `:skip` flag.
+- Each test file should have code like the following at the top of the file. This allows the tests to be run on CI and configures tests to be skipped with the `:pending` flag.
 
 ```elixir
 if !System.get_env("EXERCISM_TEST_EXAMPLES") do
@@ -45,13 +45,13 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 ```
 
-- All but the initial test for each exercise should be tagged `:skip`.
+- All but the initial test for each exercise should be tagged `:pending`.
 
 ```elixir
-@tag :skip
+@tag :pending
 test "shouting" do
   assert Bob.hey("WATCH OUT!") == "Whoa, chill out!"
 end

--- a/SETUP.md
+++ b/SETUP.md
@@ -14,12 +14,12 @@ $ elixir bob_test.exs
 In the test suites, all but the first test have been skipped.
 
 Once you get a test passing, you can unskip the next one by
-commenting out the relevant `@tag :skip` with a `#` symbol.
+commenting out the relevant `@tag :pending` with a `#` symbol.
 
 For example:
 
 ```elixir
-# @tag :skip
+# @tag :pending
 test "shouting" do
   assert Bob.hey("WATCH OUT!") == "Whoa, chill out!"
 end
@@ -29,7 +29,7 @@ Or, you can enable all the tests by commenting out the
 `ExUnit.configure` line in the test suite.
 
 ```elixir
-# ExUnit.configure trace: true
+# ExUnit.configure exclude: :pending, trace: true
 ```
 
 For more detailed information about the Elixir track, please

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -14,12 +14,12 @@ $ elixir bob_test.exs
 In the test suites, all but the first test have been skipped.
 
 Once you get a test passing, you can unskip the next one by
-commenting out the relevant `@tag :skip` with a `#` symbol.
+commenting out the relevant `@tag :pending` with a `#` symbol.
 
 For example:
 
 ```elixir
-# @tag :skip
+# @tag :pending
 test "shouting" do
   assert Bob.hey("WATCH OUT!") == "Whoa, chill out!"
 end
@@ -29,5 +29,5 @@ Or, you can enable all the tests by commenting out the
 `ExUnit.configure` line in the test suite.
 
 ```elixir
-# ExUnit.configure trace: true
+# ExUnit.configure exclude: :pending, trace: true
 ```

--- a/exercises/accumulate/accumulate_test.exs
+++ b/exercises/accumulate/accumulate_test.exs
@@ -3,7 +3,7 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule AccumulateTest do
   use ExUnit.Case
@@ -12,18 +12,18 @@ defmodule AccumulateTest do
     assert Accumulate.accumulate([], fn(n) -> n * n end) == []
   end
 
-  @tag :skip
+  @tag :pending
   test "accumulate square numbers" do
     assert Accumulate.accumulate([1, 2, 3], fn(n) -> n * n end) == [1, 4, 9]
   end
 
-  @tag :skip
+  @tag :pending
   test "accumulate upcased strings" do
     fun = fn(w) -> String.upcase(w) end
     assert Accumulate.accumulate(["hello", "world"], fun) == ["HELLO", "WORLD"]
   end
 
-  @tag :skip
+  @tag :pending
   test "accumulate reversed strings" do
     fun = fn(w) -> String.reverse(w) end
     words = ~w(the quick brown fox etc)
@@ -31,7 +31,7 @@ defmodule AccumulateTest do
     assert Accumulate.accumulate(words, fun) == expected
   end
 
-  @tag :skip
+  @tag :pending
   test "accumulate recursively" do
     chars = ~w(a b c)
     nums  = ~w(1 2 3)

--- a/exercises/acronym/acronym_test.exs
+++ b/exercises/acronym/acronym_test.exs
@@ -3,7 +3,7 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule AcronymTest do
   use ExUnit.Case
@@ -12,22 +12,22 @@ defmodule AcronymTest do
     assert Acronym.abbreviate("Portable Networks Graphic") === "PNG"
   end
 
-  @tag :skip
+  @tag :pending
   test "it produces acronyms from lower case" do
     assert Acronym.abbreviate("Ruby on Rails") === "ROR"
   end
 
-  @tag :skip
+  @tag :pending
   test "it produces acronyms from inconsistent case" do
     assert Acronym.abbreviate("HyperText Markup Language") === "HTML"
   end
 
-  @tag :skip
+  @tag :pending
   test "it ignores punctuation" do
     assert Acronym.abbreviate("First in, First out") === "FIFO"
   end
 
-  @tag :skip
+  @tag :pending
   test "it produces acronyms ignoring punctuation and casing" do
     assert Acronym.abbreviate("Complementary Metal-Oxide semiconductor") === "CMOS"
   end

--- a/exercises/allergies/allergies_test.exs
+++ b/exercises/allergies/allergies_test.exs
@@ -4,69 +4,69 @@ end
 
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule AllergiesTest do
   use ExUnit.Case
 
-  # @tag :skip
+  # @tag :pending
   test "no_allergies_at_all" do
     Allergies.list(0) |> assert_is_a_set_containing([])
   end
 
-  @tag :skip
+  @tag :pending
   test "allergic_to_just_eggs" do
     Allergies.list(1) |> assert_is_a_set_containing(~w[eggs])
   end
 
-  @tag :skip
+  @tag :pending
   test "allergic_to_just_peanuts" do
     Allergies.list(2) |> assert_is_a_set_containing(~w[peanuts])
   end
 
-  @tag :skip
+  @tag :pending
   test "allergic_to_just_strawberries" do
     Allergies.list(8) |> assert_is_a_set_containing(~w[strawberries])
   end
 
-  @tag :skip
+  @tag :pending
   test "allergic_to_eggs_and_peanuts" do
     Allergies.list(3) |> assert_is_a_set_containing(~w[eggs peanuts])
   end
 
-  @tag :skip
+  @tag :pending
   test "allergic_to_more_than_eggs_but_not_peanuts" do
     Allergies.list(5) |> assert_is_a_set_containing(~w[eggs shellfish])
   end
 
-  @tag :skip
+  @tag :pending
   test "allergic_to_lots_of_stuff" do
     Allergies.list(248) |> assert_is_a_set_containing(~w[strawberries tomatoes chocolate pollen cats])
   end
 
-  @tag :skip
+  @tag :pending
   test "allergic_to_everything" do
     Allergies.list(255) |> assert_is_a_set_containing(~w[eggs peanuts shellfish strawberries tomatoes chocolate pollen cats])
   end
 
-  @tag :skip
+  @tag :pending
   test "no_allergies_means_not_allergic" do
     refute Allergies.allergic_to?(0, "peanuts")
     refute Allergies.allergic_to?(0, "cats")
     refute Allergies.allergic_to?(0, "strawberries")
   end
 
-  @tag :skip
+  @tag :pending
   test "is_allergic_to_eggs" do
     assert Allergies.allergic_to?(1, "eggs")
   end
 
-  @tag :skip
+  @tag :pending
   test "allergic_to_eggs_in_addition_to_other_stuff" do
     assert Allergies.allergic_to?(5, "eggs")
   end
 
-  @tag :skip
+  @tag :pending
   test "ignore_non_allergen_score_parts" do
     Allergies.list(509) |> assert_is_a_set_containing(~w[eggs shellfish strawberries tomatoes chocolate pollen cats])
   end

--- a/exercises/anagram/anagram_test.exs
+++ b/exercises/anagram/anagram_test.exs
@@ -3,72 +3,72 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule AnagramTest do
   use ExUnit.Case
 
-  # @tag :skip
+  # @tag :pending
   test "no matches" do
     matches = Anagram.match "diaper", ["hello", "world", "zombies", "pants"]
     assert matches == []
   end
 
-  @tag :skip
+  @tag :pending
   test "detect simple anagram" do
     matches = Anagram.match "ant", ["tan", "stand", "at"]
     assert matches == ["tan"]
   end
 
-  @tag :skip
+  @tag :pending
   test "detect multiple anagrams" do
     matches = Anagram.match "master", ["stream", "pigeon", "maters"]
     assert matches == ["stream", "maters"]
   end
 
-  @tag :skip
+  @tag :pending
   test "do not detect anagram subsets" do
     matches = Anagram.match "good", ~w(dog goody)
     assert matches == []
   end
 
-  @tag :skip
+  @tag :pending
   test "detect anagram" do
     matches = Anagram.match "listen", ~w(enlists google inlets banana)
     assert matches == ["inlets"]
   end
 
-  @tag :skip
+  @tag :pending
   test "multiple anagrams" do
     matches = Anagram.match "allergy", ~w(gallery ballerina regally clergy largely leading)
     assert matches == ["gallery", "regally", "largely"]
   end
 
-  @tag :skip
+  @tag :pending
   test "anagrams must use all letters exactly once" do
     matches = Anagram.match "patter", ["tapper"]
     assert matches == []
   end
 
-  @tag :skip
+  @tag :pending
   test "detect anagrams with case-insensitive subject" do
     matches = Anagram.match "Orchestra", ~w(cashregister carthorse radishes)
     assert matches == ["carthorse"]
   end
 
-  @tag :skip
+  @tag :pending
   test "detect anagrams with case-insensitive candidate" do
     matches = Anagram.match "orchestra", ~w(cashregister Carthorse radishes)
     assert matches == ["Carthorse"]
   end
 
-  @tag :skip
+  @tag :pending
   test "anagrams must not be the source word" do
     matches = Anagram.match "corn", ["corn", "dark", "Corn", "rank", "CORN", "cron", "park"]
     assert matches == ["cron"]
   end
 
-  @tag :skip
+  @tag :pending
   test "do not detect words based on checksum" do
     matches = Anagram.match "mass", ["last"]
     assert matches == []

--- a/exercises/atbash-cipher/atbash_cipher_test.exs
+++ b/exercises/atbash-cipher/atbash_cipher_test.exs
@@ -3,47 +3,47 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule AtbashTest do
   use ExUnit.Case
 
-  # @tag :skip
+  # @tag :pending
   test "encode no" do
     assert Atbash.encode("no") == "ml"
   end
 
-  @tag :skip
+  @tag :pending
   test "encode yes" do
     assert Atbash.encode("yes") == "bvh"
   end
 
-  @tag :skip
+  @tag :pending
   test "encode OMG" do
     assert Atbash.encode("OMG") == "lnt"
   end
 
-  @tag :skip
+  @tag :pending
   test "encode O M G" do
     assert Atbash.encode("O M G") == "lnt"
   end
 
-  @tag :skip
+  @tag :pending
   test "encode long word" do
     assert Atbash.encode("mindblowingly") == "nrmwy oldrm tob"
   end
 
-  @tag :skip
+  @tag :pending
   test "encode numbers" do
     assert Atbash.encode("Testing, 1 2 3, testing.") == "gvhgr mt123 gvhgr mt"
   end
 
-  @tag :skip
+  @tag :pending
   test "encode sentence" do
     assert Atbash.encode("Truth is fiction.") == "gifgs rhurx grlm"
   end
 
-  @tag :skip
+  @tag :pending
   test "encode all the things" do
     plaintext = "The quick brown fox jumps over the lazy dog."
     cipher = "gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt"

--- a/exercises/bank-account/bank_account_test.exs
+++ b/exercises/bank-account/bank_account_test.exs
@@ -3,7 +3,7 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 # The BankAccount module should support four calls:
 #
@@ -30,19 +30,19 @@ defmodule BankAccountTest do
     { :ok, account: account }
   end
 
-  # @tag :skip
+  # @tag :pending
   test "initial balance is 0", %{account: account} do
     assert BankAccount.balance(account) == 0
   end
 
-  @tag :skip
+  @tag :pending
   test "incrementing and checking balance", %{account: account} do
     assert BankAccount.balance(account) == 0
     BankAccount.update(account, 10)
     assert BankAccount.balance(account) == 10
   end
 
-  @tag :skip
+  @tag :pending
   test "amount is added to balance", %{account: account} do
     assert BankAccount.balance(account) == 0
     BankAccount.update(account, 10)
@@ -50,7 +50,7 @@ defmodule BankAccountTest do
     assert BankAccount.balance(account) == 20
   end
 
-  @tag :skip
+  @tag :pending
   test "incrementing balance from another process then checking it from test process", %{account: account} do
     assert BankAccount.balance(account) == 0
     this = self()

--- a/exercises/beer-song/beer_song_test.exs
+++ b/exercises/beer-song/beer_song_test.exs
@@ -3,7 +3,7 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule BeerSongTest do
   use ExUnit.Case
@@ -15,7 +15,7 @@ defmodule BeerSongTest do
     """
   end
 
-  @tag :skip
+  @tag :pending
   test "getting just the 99th verse" do
     assert BeerSong.verse(99) == """
     98 bottles of beer on the wall, 98 bottles of beer.
@@ -23,7 +23,7 @@ defmodule BeerSongTest do
     """
   end
 
-  @tag :skip
+  @tag :pending
   test "getting just the 2nd verse" do
     assert BeerSong.verse(2) == """
     1 bottle of beer on the wall, 1 bottle of beer.
@@ -31,7 +31,7 @@ defmodule BeerSongTest do
     """
   end
 
-  @tag :skip
+  @tag :pending
   test "getting just the 1st verse" do
     assert BeerSong.verse(1) == """
     No more bottles of beer on the wall, no more bottles of beer.
@@ -39,7 +39,7 @@ defmodule BeerSongTest do
     """
   end
 
-  @tag :skip
+  @tag :pending
   test "getting the last 4 verses" do
     assert BeerSong.lyrics(4..1) == """
     3 bottles of beer on the wall, 3 bottles of beer.
@@ -56,7 +56,7 @@ defmodule BeerSongTest do
     """
   end
 
-  @tag :skip
+  @tag :pending
   test "getting the whole song" do
     assert BeerSong.lyrics == """
     99 bottles of beer on the wall, 99 bottles of beer.

--- a/exercises/binary-search/binary_search_test.exs
+++ b/exercises/binary-search/binary_search_test.exs
@@ -3,7 +3,7 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule BinarySearchTest do
   use ExUnit.Case
@@ -12,32 +12,32 @@ defmodule BinarySearchTest do
     assert BinarySearch.search({}, 2) == :not_found
   end
 
-  @tag :skip
+  @tag :pending
   test "returns :not_found when key is not in the tuple" do
     assert BinarySearch.search({2, 4, 6}, 3) == :not_found
   end
 
-  @tag :skip
+  @tag :pending
   test "finds key in a tuple with a single item" do
     assert BinarySearch.search({3}, 3) == {:ok, 0}
   end
 
-  @tag :skip
+  @tag :pending
   test "finds key when it is the first element in tuple" do
     assert BinarySearch.search({1, 2, 4, 5, 6}, 1) == {:ok, 0}
   end
 
-  @tag :skip
+  @tag :pending
   test "finds key when it is in the middle of the tuple" do
     assert BinarySearch.search({1, 2, 4, 5, 6}, 4) == {:ok, 2}
   end
 
-  @tag :skip
+  @tag :pending
   test "finds key when it is the last element in tuple" do
     assert BinarySearch.search({1, 2, 4, 5, 6}, 6) == {:ok, 4}
   end
 
-  @tag :skip
+  @tag :pending
   test "finds key in a tuple with an even number of elements" do
     tuple = {1, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377}
     assert BinarySearch.search(tuple, 21) == {:ok, 5}

--- a/exercises/binary/binary_test.exs
+++ b/exercises/binary/binary_test.exs
@@ -3,67 +3,67 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule BinaryTest do
   use ExUnit.Case
 
-  # @tag :skip
+  # @tag :pending
   test "binary 1 is decimal 1" do
     assert Binary.to_decimal("1") == 1
   end
 
-  @tag :skip
+  @tag :pending
   test "binary 10 is decimal 2" do
     assert Binary.to_decimal("10") == 2
   end
 
-  @tag :skip
+  @tag :pending
   test "binary 11 is decimal 3" do
     assert Binary.to_decimal("11") == 3
   end
 
-  @tag :skip
+  @tag :pending
   test "binary 100 is decimal 4" do
     assert Binary.to_decimal("100") == 4
   end
 
-  @tag :skip
+  @tag :pending
   test "binary 1001 is decimal 9" do
     assert Binary.to_decimal("1001") == 9
   end
 
-  @tag :skip
+  @tag :pending
   test "binary 11010 is decimal 26" do
     assert Binary.to_decimal("11010") == 26
   end
 
-  @tag :skip
+  @tag :pending
   test "binary 10001101000 is decimal 1128" do
     assert Binary.to_decimal("10001101000") == 1128
   end
 
-  @tag :skip
+  @tag :pending
   test "invalid binary is decimal 0" do
     assert Binary.to_decimal("carrot") == 0
   end
 
-  @tag :skip
+  @tag :pending
   test "invalid binary is decimal 0 II" do
     assert Binary.to_decimal("convert01") == 0
   end
 
-  @tag :skip
+  @tag :pending
   test "invalid binary is decimal 0 III" do
     assert Binary.to_decimal("10convert") == 0
   end
 
-  @tag :skip
+  @tag :pending
   test "invalid binary is decimal 0 IV" do
     assert Binary.to_decimal("1carrot0") == 0
   end
 
-  @tag :skip
+  @tag :pending
   test "22 is not a binary number" do
     assert Binary.to_decimal("22") == 0
   end

--- a/exercises/bob/bob_test.exs
+++ b/exercises/bob/bob_test.exs
@@ -3,7 +3,7 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule BobTest do
   use ExUnit.Case
@@ -12,72 +12,72 @@ defmodule BobTest do
     assert Bob.hey("Tom-ay-to, tom-aaaah-to.") == "Whatever."
   end
 
-  @tag :skip
+  @tag :pending
   test "shouting" do
     assert Bob.hey("WATCH OUT!") == "Whoa, chill out!"
   end
 
-  @tag :skip
+  @tag :pending
   test "asking a question" do
     assert Bob.hey("Does this cryogenic chamber make me look fat?") == "Sure."
   end
 
-  @tag :skip
+  @tag :pending
   test "talking forcefully" do
     assert Bob.hey("Let's go make out behind the gym!") == "Whatever."
   end
 
-  @tag :skip
+  @tag :pending
   test "talking in capitals" do
     assert Bob.hey("This Isn't Shouting!") == "Whatever."
   end
 
-  @tag :skip
+  @tag :pending
   test "asking in capitals" do
     assert Bob.hey("THIS ISN'T SHOUTING?") == "Sure."
   end
 
-  @tag :skip
+  @tag :pending
   test "shouting numbers" do
     assert Bob.hey("1, 2, 3 GO!") == "Whoa, chill out!"
   end
 
-  @tag :skip
+  @tag :pending
   test "shouting with special characters" do
     assert Bob.hey("ZOMG THE %^*@#$(*^ ZOMBIES ARE COMING!!11!!1!") == "Whoa, chill out!"
   end
 
-  @tag :skip
+  @tag :pending
   test "shouting with no exclamation mark" do
     assert Bob.hey("I HATE YOU") == "Whoa, chill out!"
   end
 
-  @tag :skip
+  @tag :pending
   test "statement containing question mark" do
     assert Bob.hey("Ending with ? means a question.") == "Whatever."
   end
 
-  @tag :skip
+  @tag :pending
   test "silence" do
     assert Bob.hey("") == "Fine. Be that way!"
   end
 
-  @tag :skip
+  @tag :pending
   test "prolonged silence" do
     assert Bob.hey("  ") == "Fine. Be that way!"
   end
 
-  @tag :skip
+  @tag :pending
   test "only numbers" do
     assert Bob.hey("1, 2, 3") == "Whatever."
   end
 
-  @tag :skip
+  @tag :pending
   test "question with numbers" do
     assert Bob.hey("4?") == "Sure."
   end
 
-  @tag :skip
+  @tag :pending
   test "shouting in Russian" do
     assert Bob.hey("УХОДИ") == "Whoa, chill out!"
   end

--- a/exercises/bowling/bowling_test.exs
+++ b/exercises/bowling/bowling_test.exs
@@ -3,7 +3,7 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule BowlingTest do
   use ExUnit.Case
@@ -28,7 +28,7 @@ defmodule BowlingTest do
     assert Bowling.score(game) == 0
   end
 
-  @tag :skip
+  @tag :pending
   test "can score an open frame" do
     game = Bowling.start
     rolls = [3, 4,
@@ -45,7 +45,7 @@ defmodule BowlingTest do
     assert Bowling.score(game) == 7
   end
 
-  @tag :skip
+  @tag :pending
   test "can score multiple frames" do
     game = Bowling.start
     rolls = [3, 4,
@@ -62,7 +62,7 @@ defmodule BowlingTest do
     assert Bowling.score(game) == 19
   end
 
-  @tag :skip
+  @tag :pending
   test "can score a game with all single pin rolls" do
     game = Bowling.start
     rolls = [1, 1,
@@ -79,7 +79,7 @@ defmodule BowlingTest do
     assert Bowling.score(game) == 20
   end
 
-  @tag :skip
+  @tag :pending
   test "can score a game with all open frames" do
     game = Bowling.start
     rolls = [3, 6,
@@ -96,7 +96,7 @@ defmodule BowlingTest do
     assert Bowling.score(game) == 90
   end
 
-  @tag :skip
+  @tag :pending
   test "can score a game with a strike not in the last frame" do
     game = Bowling.start
     rolls = [10,
@@ -113,7 +113,7 @@ defmodule BowlingTest do
     assert Bowling.score(game) == 26
   end
 
-  @tag :skip
+  @tag :pending
   test "can score a game with a spare not in the last frame" do
     game = Bowling.start
     rolls = [5, 5,
@@ -130,7 +130,7 @@ defmodule BowlingTest do
     assert Bowling.score(game) == 20
   end
 
-  @tag :skip
+  @tag :pending
   test "can score a game with multiple strikes in a row" do
     game = Bowling.start
     rolls = [10,
@@ -147,7 +147,7 @@ defmodule BowlingTest do
     assert Bowling.score(game) == 81
   end
 
-  @tag :skip
+  @tag :pending
   test "can score a game with multiple spares in a row" do
     game = Bowling.start
     rolls = [5, 5,
@@ -164,7 +164,7 @@ defmodule BowlingTest do
     assert Bowling.score(game) == 32
   end
 
-  @tag :skip
+  @tag :pending
   test "fills out the last frame when there is a strike" do
     game = Bowling.start
     rolls = [0, 0,
@@ -182,7 +182,7 @@ defmodule BowlingTest do
     assert Bowling.score(game) == 18
   end
 
-  @tag :skip
+  @tag :pending
   test "fills out the last frame when there is a spare" do
     game = Bowling.start
     rolls = [0, 0,
@@ -200,7 +200,7 @@ defmodule BowlingTest do
     assert Bowling.score(game) == 17
   end
 
-  @tag :skip
+  @tag :pending
   test "allows filled balls to be strikes" do
     game = Bowling.start
     rolls = [0, 0,
@@ -219,7 +219,7 @@ defmodule BowlingTest do
     assert Bowling.score(game) == 30
   end
 
-  @tag :skip
+  @tag :pending
   test "scores a perfect game correctly" do
     game = Bowling.start
     rolls = [10,
@@ -238,26 +238,26 @@ defmodule BowlingTest do
     assert Bowling.score(game) == 300
   end
 
-  @tag :skip
+  @tag :pending
   test "does not allow negative rolls" do
     game = Bowling.start
     assert Bowling.roll(game, -1) == {:error, "Pins must have a value from 0 to 10"}
   end
 
-  @tag :skip
+  @tag :pending
   test "does not allow rolls greater than a strike" do
     game = Bowling.start
     assert Bowling.roll(game, 11) == {:error, "Pins must have a value from 0 to 10"}
   end
 
-  @tag :skip
+  @tag :pending
   test "does not allow consecutive rolls to be greater than a strike" do
     game = Bowling.start
     game = Bowling.roll(game, 5)
     assert Bowling.roll(game, 6) == {:error, "Pin count exceeds pins on the lane"}
   end
 
-  @tag :skip
+  @tag :pending
   test "does not allow pin count to be exeeded in last frame" do
     game = Bowling.start
     rolls = [0, 0,
@@ -274,7 +274,7 @@ defmodule BowlingTest do
     assert Bowling.roll(game, 6) == {:error, "Pin count exceeds pins on the lane"}
   end
 
-  @tag :skip
+  @tag :pending
   test "score cannot be taken until the end of the game" do
     game = Bowling.start
     game = Bowling.roll(game, 0)

--- a/exercises/bracket-push/bracket_push_test.exs
+++ b/exercises/bracket-push/bracket_push_test.exs
@@ -3,62 +3,62 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule BracketPushTest do
   use ExUnit.Case
 
-  # @tag :skip
+  # @tag :pending
   test "empty string" do
     assert BracketPush.check_brackets("")
   end
 
-  @tag :skip
+  @tag :pending
   test "appropriate bracketing in a set of brackets" do
     assert BracketPush.check_brackets("{}")
   end
 
-  @tag :skip
+  @tag :pending
   test "unclosed brackets" do
     refute BracketPush.check_brackets("{{")
   end
 
-  @tag :skip
+  @tag :pending
   test "more than one pair of brackets" do
     assert BracketPush.check_brackets("{}[]")
   end
 
-  @tag :skip
+  @tag :pending
   test "brackets are out of order" do
     refute BracketPush.check_brackets("}{")
   end
 
-  @tag :skip
+  @tag :pending
   test "nested brackets" do
     assert BracketPush.check_brackets("{[()]}")
   end
 
-  @tag :skip
+  @tag :pending
   test "unbalanced nested brackets" do
     refute BracketPush.check_brackets("{[}]")
   end
 
-  @tag :skip
+  @tag :pending
   test "bracket closure with deeper nesting" do
     refute BracketPush.check_brackets("{[)][]}")
   end
 
-  @tag :skip
+  @tag :pending
   test "bracket closure in a long string of brackets" do
     assert BracketPush.check_brackets("{[]([()])}")
   end
 
-  @tag :skip
+  @tag :pending
   test "should ignore non-bracket characters" do
     assert BracketPush.check_brackets("{hello[]([a()])b}c")
   end
 
-  @tag :skip
+  @tag :pending
   test "string with newlines" do
     assert BracketPush.check_brackets("[]\n{()}\n[(({}))]\n")
   end

--- a/exercises/change/change_test.exs
+++ b/exercises/change/change_test.exs
@@ -3,7 +3,7 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule ChangeTest do
   use ExUnit.Case
@@ -12,37 +12,37 @@ defmodule ChangeTest do
     assert Change.generate(1, []) == :error
   end
 
-  @tag :skip
+  @tag :pending
   test "generates the correct change when only one coin type is needed" do
     change = %{1 => 5, 10 => 0}
     assert Change.generate(5, [1, 10]) == {:ok, change}
   end
 
-  @tag :skip
+  @tag :pending
   test "generates the correct change when multiple coin types are needed" do
     change = %{1 => 3, 5 => 1, 10 => 1}
     assert Change.generate(18, [1, 5, 10]) == {:ok, change}
   end
 
-  @tag :skip
+  @tag :pending
   test "returns :error when it is not possible to generate change" do
     assert Change.generate(3, [5, 10, 25]) == :error
   end
 
-  @tag :skip
+  @tag :pending
   test "generates change using only small coins when it is not possible to combine them with larger coins" do
     change = %{3 => 34, 100 => 0}
     assert Change.generate(102, [3, 100]) == {:ok, change}
   end
 
-  @tag :skip
+  @tag :pending
   test "generates the same change given any coin order" do
     change = %{1 => 3, 5 => 1, 10 => 1}
     assert Change.generate(18, [1, 5, 10]) == {:ok, change}
     assert Change.generate(18, [10, 5, 1]) == {:ok, change}
   end
 
-  @tag :skip
+  @tag :pending
   test "generates the correct change for large values with many coins" do
     change = %{1 => 3, 5 => 1, 10 => 0, 25 => 1, 100 => 1}
     assert Change.generate(133, [1, 5, 10, 25, 100]) == {:ok, change}

--- a/exercises/connect/connect_test.exs
+++ b/exercises/connect/connect_test.exs
@@ -3,7 +3,7 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule ConnectTest do
   use ExUnit.Case
@@ -12,7 +12,7 @@ defmodule ConnectTest do
     Enum.map(rows, &String.replace(&1, " ", ""))
   end
 
-  # @tag :skip
+  # @tag :pending
   test "empty board has no winner" do
     board = remove_spaces [
       ". . . . .",
@@ -24,19 +24,19 @@ defmodule ConnectTest do
     assert Connect.result_for(board) == :none
   end
 
-  @tag :skip
+  @tag :pending
   test "1x1 board with black stone" do
     board = ["X"]
     assert Connect.result_for(board) == :black
   end
 
-  @tag :skip
+  @tag :pending
   test "1x1 board with white stone" do
     board = ["O"]
     assert Connect.result_for(board) == :white
   end
 
-  @tag :skip
+  @tag :pending
   test "convulted path" do
     board = remove_spaces [
       ". X X . .",
@@ -48,7 +48,7 @@ defmodule ConnectTest do
     assert Connect.result_for(board) == :black
   end
 
-  @tag :skip
+  @tag :pending
   test "rectangle, black wins" do
     board = remove_spaces [
       ". O . .",
@@ -60,7 +60,7 @@ defmodule ConnectTest do
     assert Connect.result_for(board) == :black
   end
 
-  @tag :skip
+  @tag :pending
   test "rectangle, white wins" do
     board = remove_spaces [
       ". O . .",
@@ -72,7 +72,7 @@ defmodule ConnectTest do
     assert Connect.result_for(board) == :white
   end
 
-  @tag :skip
+  @tag :pending
   test "spiral, black wins" do
     board = [
       "OXXXXXXXX",
@@ -88,7 +88,7 @@ defmodule ConnectTest do
     assert Connect.result_for(board) == :black
   end
 
-  @tag :skip
+  @tag :pending
   test "spiral, nobody wins" do
     board = [
       "OXXXXXXXX",

--- a/exercises/crypto-square/crypto_square_test.exs
+++ b/exercises/crypto-square/crypto_square_test.exs
@@ -3,37 +3,37 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule CryptoSquareTest do
   use ExUnit.Case
 
-  # @tag :skip
+  # @tag :pending
   test "empty string" do
     assert CryptoSquare.encode("") == ""
   end
 
-  @tag :skip
+  @tag :pending
   test "perfect square" do
     assert CryptoSquare.encode("abcd") == "ac bd"
   end
 
-  @tag :skip
+  @tag :pending
   test "uppercase string" do
     assert CryptoSquare.encode("ABCD") == "ac bd"
   end
 
-  @tag :skip
+  @tag :pending
   test "small imperfect square" do
     assert CryptoSquare.encode("This is easy") == "tis hsy ie sa"
   end
 
-  @tag :skip
+  @tag :pending
   test "punctuation and numbers" do
     assert CryptoSquare.encode("1, 2, 3, Go! Go, for God's sake!") == "1gga 2ook 3fde gos ors"
   end
 
-  @tag :skip
+  @tag :pending
   test "long string" do
     msg = "If man was meant to stay on the ground, god would have given us roots."
     cipher = "imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn sseoau"

--- a/exercises/custom-set/custom_set_test.exs
+++ b/exercises/custom-set/custom_set_test.exs
@@ -3,12 +3,12 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule CustomSetTest do
   use ExUnit.Case
 
-  # @tag :skip
+  # @tag :pending
   describe "new" do
     test "returns a CustomSet struct" do
       assert CustomSet.new([]) == %CustomSet{}
@@ -21,7 +21,7 @@ defmodule CustomSetTest do
     end
   end
 
-  @tag :skip
+  @tag :pending
   describe "empty?" do
     test "sets with no elements are empty" do
       custom_set = CustomSet.new([])
@@ -34,7 +34,7 @@ defmodule CustomSetTest do
     end
   end
 
-  @tag :skip
+  @tag :pending
   describe "contains?" do
     test "nothing is contained in an empty set" do
       custom_set = CustomSet.new([])
@@ -52,7 +52,7 @@ defmodule CustomSetTest do
     end
   end
 
-  @tag :skip
+  @tag :pending
   describe "subset?" do
     test "empty set is a subset of another empty set" do
       custom_set_1 = CustomSet.new([])
@@ -91,7 +91,7 @@ defmodule CustomSetTest do
     end
   end
 
-  @tag :skip
+  @tag :pending
   describe "disjoint?" do
     test "the empty set is disjoint with itself" do
       custom_set_1 = CustomSet.new([])
@@ -124,7 +124,7 @@ defmodule CustomSetTest do
     end
   end
 
-  @tag :skip
+  @tag :pending
   describe "equal?" do
     test "empty sets are equal" do
       custom_set_1 = CustomSet.new([])
@@ -157,7 +157,7 @@ defmodule CustomSetTest do
     end
   end
 
-  @tag :skip
+  @tag :pending
   describe "add" do
     test "add to empty set" do
       custom_set = CustomSet.new([])
@@ -180,7 +180,7 @@ defmodule CustomSetTest do
     end
   end
 
-  @tag :skip
+  @tag :pending
   describe "intersection" do
     test "intersection of two empty sets is an empty set" do
       custom_set_1 = CustomSet.new([])
@@ -223,7 +223,7 @@ defmodule CustomSetTest do
     end
   end
 
-  @tag :skip
+  @tag :pending
   describe "difference" do
     test "difference of two empty sets is an empty set" do
       custom_set_1 = CustomSet.new([])
@@ -258,7 +258,7 @@ defmodule CustomSetTest do
     end
   end
 
-  @tag :skip
+  @tag :pending
   describe "union" do
     test "union of empty sets is an empty set" do
       custom_set_1 = CustomSet.new([])

--- a/exercises/diamond/diamond_test.exs
+++ b/exercises/diamond/diamond_test.exs
@@ -3,18 +3,18 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule DiamondTest do
   use ExUnit.Case
 
-  # @tag :skip
+  # @tag :pending
   test "letter A" do
     shape = Diamond.build_shape(?A)
     assert shape == "A\n"
   end
 
-  @tag :skip
+  @tag :pending
   test "letter C" do
     shape = Diamond.build_shape(?C)
     assert shape == """
@@ -26,7 +26,7 @@ defmodule DiamondTest do
     """
   end
 
-  @tag :skip
+  @tag :pending
   test "letter E" do
     shape = Diamond.build_shape(?E)
     assert shape == """

--- a/exercises/difference-of-squares/difference_of_squares_test.exs
+++ b/exercises/difference-of-squares/difference_of_squares_test.exs
@@ -3,52 +3,52 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule DifferenceOfSquaresTest do
   use ExUnit.Case
 
-  # @tag :skip
+  # @tag :pending
   test "square of sums to 5" do
     assert Squares.square_of_sums(5) == 225
   end
 
-  @tag :skip
+  @tag :pending
   test "sum of squares to 5" do
     assert Squares.sum_of_squares(5) == 55
   end
 
-  @tag :skip
+  @tag :pending
   test "difference of sums to 5" do
     assert Squares.difference(5) == 170
   end
 
-  @tag :skip
+  @tag :pending
   test "square of sums to 10" do
     assert Squares.square_of_sums(10) == 3025
   end
 
-  @tag :skip
+  @tag :pending
   test "sum of squares to 10" do
     assert Squares.sum_of_squares(10) == 385
   end
 
-  @tag :skip
+  @tag :pending
   test "difference of sums to 10" do
     assert Squares.difference(10) == 2640
   end
 
-  @tag :skip
+  @tag :pending
   test "square of sums to 100" do
     assert Squares.square_of_sums(100) == 25502500
   end
 
-  @tag :skip
+  @tag :pending
   test "sum of squares to 100" do
     assert Squares.sum_of_squares(100) == 338350
   end
 
-  @tag :skip
+  @tag :pending
   test "difference of sums to 100" do
     assert Squares.difference(100) == 25164150
   end

--- a/exercises/dot-dsl/dot_dsl_test.exs
+++ b/exercises/dot-dsl/dot_dsl_test.exs
@@ -3,7 +3,7 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule DotTest do
   use ExUnit.Case
@@ -20,32 +20,32 @@ defmodule DotTest do
     end
   end
 
-  # @tag :skip
+  # @tag :pending
   test "empty graph" do
     assert %Graph{} == exprt(Dot.graph do end)
   end
 
-  @tag :skip
+  @tag :pending
   test "graph with one node" do
     assert %Graph{nodes: [{:a, []}]} == exprt(Dot.graph do a end)
   end
 
-  @tag :skip
+  @tag :pending
   test "graph with one node with keywords" do
     assert %Graph{nodes: [{:a, [color: :green]}]} == exprt(Dot.graph do a [color: :green] end)
   end
 
-  @tag :skip
+  @tag :pending
   test "graph with one edge" do
     assert %Graph{edges: [{:a, :b, []}]} == exprt(Dot.graph do a -- b end)
   end
 
-  @tag :skip
+  @tag :pending
   test "graph with just attribute" do
     assert %Graph{attrs: [foo: 1]} == exprt(Dot.graph do graph [foo: 1] end)
   end
 
-  @tag :skip
+  @tag :pending
   test "graph with attributes" do
     assert %Graph{
       attrs: [bar: true, foo: 1, title: "Testing Attrs"],
@@ -67,7 +67,7 @@ defmodule DotTest do
     end)
   end
 
-  @tag :skip
+  @tag :pending
   test "keywords stuck to graph without space" do
     assert_raise ArgumentError, fn ->
       exprt(Dot.graph do
@@ -76,7 +76,7 @@ defmodule DotTest do
     end
   end
 
-  @tag :skip
+  @tag :pending
   test "keywords stuck to node without space" do
     assert_raise ArgumentError, fn ->
       exprt(Dot.graph do
@@ -85,7 +85,7 @@ defmodule DotTest do
     end
   end
 
-  @tag :skip
+  @tag :pending
   test "keywords stuck to edge without space" do
     assert_raise ArgumentError, fn ->
       exprt(Dot.graph do
@@ -94,7 +94,7 @@ defmodule DotTest do
     end
   end
 
-  @tag :skip
+  @tag :pending
   test "invalid statement: int" do
     assert_raise ArgumentError, fn ->
       exprt(Dot.graph do
@@ -104,7 +104,7 @@ defmodule DotTest do
     end
   end
 
-  @tag :skip
+  @tag :pending
   test "invalid statement: list" do
     assert_raise ArgumentError, fn ->
       exprt(Dot.graph do
@@ -113,7 +113,7 @@ defmodule DotTest do
     end
   end
 
-  @tag :skip
+  @tag :pending
   test "invalid statement: qualified atom" do
     assert_raise ArgumentError, fn ->
       exprt(Dot.graph do
@@ -122,7 +122,7 @@ defmodule DotTest do
     end
   end
 
-  @tag :skip
+  @tag :pending
   test "invalid statement: graph with no keywords" do
     assert_raise ArgumentError, fn ->
       exprt(Dot.graph do
@@ -131,7 +131,7 @@ defmodule DotTest do
     end
   end
 
-  @tag :skip
+  @tag :pending
   test "two attribute lists" do
     assert_raise ArgumentError, fn ->
       exprt(Dot.graph do
@@ -140,7 +140,7 @@ defmodule DotTest do
     end
   end
 
-  @tag :skip
+  @tag :pending
   test "non-keyword attribute list" do
     assert_raise ArgumentError, fn ->
       exprt(Dot.graph do
@@ -149,7 +149,7 @@ defmodule DotTest do
     end
   end
 
-  @tag :skip
+  @tag :pending
   test "int edge" do
     assert_raise ArgumentError, fn ->
       exprt(Dot.graph do

--- a/exercises/etl/etl_test.exs
+++ b/exercises/etl/etl_test.exs
@@ -3,12 +3,12 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule TransformTest do
   use ExUnit.Case
 
-  # @tag :skip
+  # @tag :pending
   test "transform one value" do
     old = %{1 => ["WORLD"]}
     expected = %{"world" => 1}
@@ -16,7 +16,7 @@ defmodule TransformTest do
     assert ETL.transform(old) == expected
   end
 
-  @tag :skip
+  @tag :pending
   test "transform more values" do
     old = %{1 => ["WORLD", "GSCHOOLERS"]}
     expected = %{"world" => 1, "gschoolers" => 1}
@@ -24,7 +24,7 @@ defmodule TransformTest do
     assert ETL.transform(old) == expected
   end
 
-  @tag :skip
+  @tag :pending
   test "more keys" do
     old = %{1 => ["APPLE", "ARTICHOKE"], 2 => ["BOAT", "BALLERINA"]}
     expected = %{
@@ -37,7 +37,7 @@ defmodule TransformTest do
     assert ETL.transform(old) == expected
   end
 
-  @tag :skip
+  @tag :pending
   test "full dataset" do
     old = %{
       1 =>  ~W(A E I O U L N R S T),

--- a/exercises/flatten-array/flatten_array_test.exs
+++ b/exercises/flatten-array/flatten_array_test.exs
@@ -3,7 +3,7 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule FlattenArrayTest do
   use ExUnit.Case
@@ -12,27 +12,27 @@ defmodule FlattenArrayTest do
     assert FlattenArray.flatten([1, 2, 3]) ==  [1, 2, 3]
   end
 
-  @tag :skip
+  @tag :pending
   test "flattens an empty nested list" do
     assert FlattenArray.flatten([[]]) ==  []
   end
 
-  @tag :skip
+  @tag :pending
   test "flattens a nested list" do
     assert FlattenArray.flatten([1,[2,[3],4],5,[6,[7,8]]]) == [1, 2, 3, 4, 5, 6, 7, 8]
   end
 
-  @tag :skip
+  @tag :pending
   test "removes nil from list" do
     assert FlattenArray.flatten([1, nil, 2]) ==  [1, 2]
   end
 
-  @tag :skip
+  @tag :pending
   test "removes nil from a nested list" do
     assert FlattenArray.flatten([1, [2, nil, 4], 5]) ==  [1, 2, 4, 5]
   end
 
-  @tag :skip
+  @tag :pending
   test "returns an empty list if all values in nested list are nil" do
     assert FlattenArray.flatten([nil, [nil], [nil, [nil]]]) ==  []
   end

--- a/exercises/forth/forth_test.exs
+++ b/exercises/forth/forth_test.exs
@@ -3,18 +3,18 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule ForthTest do
   use ExUnit.Case
 
-  # @tag :skip
+  # @tag :pending
   test "no input, no stack" do
     s = Forth.new |> Forth.format_stack
     assert s == ""
   end
 
-  @tag :skip
+  @tag :pending
   test "numbers just get pushed onto the stack" do
     s = Forth.new
         |> Forth.eval("1 2 3 4 5")
@@ -22,7 +22,7 @@ defmodule ForthTest do
     assert s == "1 2 3 4 5"
   end
 
-  @tag :skip
+  @tag :pending
   test "non-word characters are separators" do
     # Note the Ogham Space Mark ( ), this is a spacing character.
     s = Forth.new
@@ -31,7 +31,7 @@ defmodule ForthTest do
     assert s == "1 2 3 4 5 6 7"
   end
 
-  @tag :skip
+  @tag :pending
   test "basic arithmetic" do
     s = Forth.new
         |> Forth.eval("1 2 + 4 -")
@@ -43,14 +43,14 @@ defmodule ForthTest do
     assert s == "2"
   end
 
-  @tag :skip
+  @tag :pending
   test "division by zero" do
     assert_raise Forth.DivisionByZero, fn ->
       Forth.new |> Forth.eval("4 2 2 - /")
     end
   end
 
-  @tag :skip
+  @tag :pending
   test "dup" do
     s = Forth.new
         |> Forth.eval("1 DUP")
@@ -65,7 +65,7 @@ defmodule ForthTest do
     end
   end
 
-  @tag :skip
+  @tag :pending
   test "drop" do
     s = Forth.new
         |> Forth.eval("1 drop")
@@ -80,7 +80,7 @@ defmodule ForthTest do
     end
   end
 
-  @tag :skip
+  @tag :pending
   test "swap" do
     s = Forth.new
         |> Forth.eval("1 2 swap")
@@ -98,7 +98,7 @@ defmodule ForthTest do
     end
   end
 
-  @tag :skip
+  @tag :pending
   test "over" do
     s = Forth.new
         |> Forth.eval("1 2 over")
@@ -116,7 +116,7 @@ defmodule ForthTest do
     end
   end
 
-  @tag :skip
+  @tag :pending
   test "defining a new word" do
     s = Forth.new
         |> Forth.eval(": dup-twice dup dup ;")
@@ -125,7 +125,7 @@ defmodule ForthTest do
     assert s == "1 1 1"
   end
 
-  @tag :skip
+  @tag :pending
   test "redefining an existing word" do
     s = Forth.new
         |> Forth.eval(": foo dup ;")
@@ -135,7 +135,7 @@ defmodule ForthTest do
     assert s == "1 1 1"
   end
 
-  @tag :skip
+  @tag :pending
   test "redefining an existing built-in word" do
     s = Forth.new
         |> Forth.eval(": swap dup ;")
@@ -144,7 +144,7 @@ defmodule ForthTest do
     assert s == "1 1"
   end
 
-  @tag :skip
+  @tag :pending
   test "defining words with odd characters" do
     s = Forth.new
         |> Forth.eval(": € 220371 ; €")
@@ -152,14 +152,14 @@ defmodule ForthTest do
     assert s == "220371"
   end
 
-  @tag :skip
+  @tag :pending
   test "defining a number" do
     assert_raise Forth.InvalidWord, fn ->
       Forth.new |> Forth.eval(": 1 2 ;")
     end
   end
 
-  @tag :skip
+  @tag :pending
   test "calling a non-existing word" do
     assert_raise Forth.UnknownWord, fn ->
       Forth.new |> Forth.eval("1 foo")

--- a/exercises/gigasecond/gigasecond_test.exs
+++ b/exercises/gigasecond/gigasecond_test.exs
@@ -3,27 +3,27 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule GigasecondTest do
   use ExUnit.Case
 
-  # @tag :skip
+  # @tag :pending
   test "from 4/25/2011" do
     assert Gigasecond.from({{2011, 4, 25}, {0, 0, 0}}) == {{2043, 1, 1}, {1, 46, 40}}
   end
 
-  @tag :skip
+  @tag :pending
   test "from 6/13/1977" do
     assert Gigasecond.from({{1977, 6, 13}, {0, 0, 0}}) == {{2009, 2, 19}, {1, 46, 40}}
   end
 
-  @tag :skip
+  @tag :pending
   test "from 7/19/1959" do
     assert Gigasecond.from({{1959, 7, 19}, {0, 0, 0}}) == {{1991, 3, 27}, {1, 46, 40}}
   end
 
-  @tag :skip
+  @tag :pending
   test "yourself" do
     # customize these values for yourself
     # your_birthday = {{year1, month1, day1}, {0, 0, 0}}

--- a/exercises/grade-school/grade_school_test.exs
+++ b/exercises/grade-school/grade_school_test.exs
@@ -3,7 +3,7 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule SchoolTest do
   use ExUnit.Case
@@ -15,7 +15,7 @@ defmodule SchoolTest do
     assert actual == %{2 =>["Aimee"]}
   end
 
-  @tag :skip
+  @tag :pending
   test "add more students in same class" do
     actual = @db
     |> School.add("James", 2)
@@ -25,7 +25,7 @@ defmodule SchoolTest do
     assert Enum.sort(actual[2]) == ["Blair", "James", "Paul"]
   end
 
-  @tag :skip
+  @tag :pending
   test "add students to different grades" do
     actual = @db
     |> School.add("Chelsea", 3)
@@ -34,7 +34,7 @@ defmodule SchoolTest do
     assert actual == %{3 => ["Chelsea"], 7 => ["Logan"]}
   end
 
-  @tag :skip
+  @tag :pending
   test "get students in a grade" do
     actual = @db
     |> School.add("Bradley", 5)
@@ -45,12 +45,12 @@ defmodule SchoolTest do
     assert Enum.sort(actual) == ["Bradley", "Franklin"]
   end
 
-  @tag :skip
+  @tag :pending
   test "get students in a non existent grade" do
     assert [] == School.grade(@db, 1)
   end
 
-  @tag :skip
+  @tag :pending
   test "sort school by grade and by student name" do
     actual = @db
     |> School.add("Bart", 4)

--- a/exercises/grains/grains_test.exs
+++ b/exercises/grains/grains_test.exs
@@ -3,7 +3,7 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 # NOTE: :math.pow/2 doesn't do what you'd expect:
 # `:math.pow(2, 64) == :math.pow(2, 64) - 1` is true.
@@ -14,42 +14,42 @@ ExUnit.configure trace: true
 defmodule GrainsTest do
   use ExUnit.Case
 
-  # @tag :skip
+  # @tag :pending
   test "square 1" do
     assert Grains.square(1) === 1
   end
 
-  @tag :skip
+  @tag :pending
   test "square 2" do
     assert Grains.square(2) === 2
   end
 
-  @tag :skip
+  @tag :pending
   test "square 3" do
     assert Grains.square(3) === 4
   end
 
-  @tag :skip
+  @tag :pending
   test "square 4" do
     assert Grains.square(4) === 8
   end
 
-  @tag :skip
+  @tag :pending
   test "square 16" do
     assert Grains.square(16) === 32768
   end
 
-  @tag :skip
+  @tag :pending
   test "square 32" do
     assert Grains.square(32) === 2147483648
   end
 
-  @tag :skip
+  @tag :pending
   test "square 64" do
     assert Grains.square(64) === 9223372036854775808
   end
 
-  @tag :skip
+  @tag :pending
   test "total grains" do
     assert Grains.total === 18446744073709551615
   end

--- a/exercises/hamming/hamming_test.exs
+++ b/exercises/hamming/hamming_test.exs
@@ -3,7 +3,7 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule HammingTest do
   use ExUnit.Case
@@ -12,27 +12,27 @@ defmodule HammingTest do
     assert Hamming.hamming_distance('', '') == {:ok, 0}
   end
 
-  @tag :skip
+  @tag :pending
   test "no difference between identical strands" do
     assert Hamming.hamming_distance('GGACTGA', 'GGACTGA') == {:ok, 0}
   end
 
-  @tag :skip
+  @tag :pending
   test "small hamming distance in middle somewhere" do
     assert Hamming.hamming_distance('GGACG', 'GGTCG') == {:ok, 1}
   end
 
-  @tag :skip
+  @tag :pending
   test "distance with same nucleotides in different locations" do
     assert Hamming.hamming_distance('TAG', 'GAT') == {:ok, 2}
   end
 
-  @tag :skip
+  @tag :pending
   test "larger distance" do
     assert Hamming.hamming_distance('ACCAGGG', 'ACTATGG') == {:ok, 2}
   end
 
-  @tag :skip
+  @tag :pending
   test "hamming distance is undefined for strands of different lengths" do
     assert {:error, "Lists must be the same length"} = Hamming.hamming_distance('AAAC', 'TAGGGGAGGCTAGCGGTAGGAC')
     assert {:error, "Lists must be the same length"} = Hamming.hamming_distance('GACTACGGACAGGACACC', 'GACATCGC')

--- a/exercises/hello-world/hello_world_test.exs
+++ b/exercises/hello-world/hello_world_test.exs
@@ -3,7 +3,7 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule HelloWorldTest do
   use ExUnit.Case
@@ -12,12 +12,12 @@ defmodule HelloWorldTest do
     assert HelloWorld.hello() == "Hello, World!"
   end
 
-  @tag :skip
+  @tag :pending
   test "says hello sample name" do
     assert HelloWorld.hello("Alice") == "Hello, Alice!"
   end
 
-  @tag :skip
+  @tag :pending
   test "says hello other sample name" do
     assert HelloWorld.hello("Bob") == "Hello, Bob!"
   end

--- a/exercises/hexadecimal/hexadecimal_test.exs
+++ b/exercises/hexadecimal/hexadecimal_test.exs
@@ -3,7 +3,7 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule HexadecimalTest do
   use ExUnit.Case
@@ -12,52 +12,52 @@ defmodule HexadecimalTest do
     assert Hexadecimal.to_decimal("1") ==  1
   end
 
-  @tag :skip
+  @tag :pending
   test "returns 12 when hex is c" do
     assert Hexadecimal.to_decimal("c") == 12
   end
 
-  @tag :skip
+  @tag :pending
   test "hexadecimal is case insensitive" do
     assert Hexadecimal.to_decimal("C") == 12
   end
 
-  @tag :skip
+  @tag :pending
   test "returns 16 when hex is 10" do
     assert Hexadecimal.to_decimal("10") == 16
   end
 
-  @tag :skip
+  @tag :pending
   test "returns 175 when hex is af" do
     assert Hexadecimal.to_decimal("af") == 175
   end
 
-  @tag :skip
+  @tag :pending
   test "returns 256 when hex is 100" do
     assert Hexadecimal.to_decimal("100") == 256
   end
 
-  @tag :skip
+  @tag :pending
   test "returns 105_166 when hex is 19ace" do
     assert Hexadecimal.to_decimal("19ace") == 105_166
   end
 
-  @tag :skip
+  @tag :pending
   test "returns 0 when hex is invalid" do
     assert Hexadecimal.to_decimal("carrot") == 0
   end
 
-  @tag :skip
+  @tag :pending
   test "returns 0 when hex represents black" do
     assert Hexadecimal.to_decimal("000000") == 0
   end
 
-  @tag :skip
+  @tag :pending
   test "returns 16_777_215 when hex represents white" do
     assert Hexadecimal.to_decimal("ffffff") == 16_777_215
   end
 
-  @tag :skip
+  @tag :pending
   test "returns 16_776_960 when hex represents yellow" do
     assert Hexadecimal.to_decimal("ffff00") == 16_776_960
   end

--- a/exercises/isogram/isogram_test.exs
+++ b/exercises/isogram/isogram_test.exs
@@ -3,7 +3,7 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule IsogramTest do
   use ExUnit.Case
@@ -12,47 +12,47 @@ defmodule IsogramTest do
     assert Isogram.isogram?("subdermatoglyphic")
   end
 
-  @tag :skip
+  @tag :pending
   test "not isogram lowercase " do
     refute Isogram.isogram?("eleven")
   end
 
-  @tag :skip
+  @tag :pending
   test "isogram uppercase" do
     assert Isogram.isogram?("DEMONSTRABLY")
   end
 
-  @tag :skip
+  @tag :pending
   test "not isogram uppercase" do
     refute Isogram.isogram?("ALPHABET")
   end
 
-  @tag :skip
+  @tag :pending
   test "isogram with dash" do
     assert Isogram.isogram?("hjelmqvist-gryb-zock-pfund-wax")
   end
 
-  @tag :skip
+  @tag :pending
   test "not isogram with dash" do
     refute Isogram.isogram?("twenty-five")
   end
 
-  @tag :skip
+  @tag :pending
   test "isogram with utf-8 letters" do
     assert Isogram.isogram?("heizölrückstoßabdämpfung")
   end
 
-  @tag :skip
+  @tag :pending
   test "not isogram with utf-8 letters" do
     refute Isogram.isogram?("éléphant")
   end
 
-  @tag :skip
+  @tag :pending
   test "phrase is isogram" do
     assert Isogram.isogram?("emily jung schwartzkopf")
   end
 
-  @tag :skip
+  @tag :pending
   test "phrase is not isogram" do
     refute Isogram.isogram?("the quick brown fox")
   end

--- a/exercises/kindergarten-garden/garden_test.exs
+++ b/exercises/kindergarten-garden/garden_test.exs
@@ -3,7 +3,7 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule GardenTest do
   use ExUnit.Case
@@ -13,25 +13,25 @@ defmodule GardenTest do
     assert garden_info.alice == {:radishes, :clover, :grass, :grass}
   end
 
-  @tag :skip
+  @tag :pending
   test "gets another garden for Alice with just her plants" do
     garden_info = Garden.info("VC\nRC")
     assert garden_info.alice == {:violets, :clover, :radishes, :clover}
   end
 
-  @tag :skip
+  @tag :pending
   test "returns an empty tuple if the child has no plants" do
     garden_info = Garden.info("VC\nRC")
     assert garden_info.bob == {}
   end
 
-  @tag :skip
+  @tag :pending
   test "gets the garden for Bob" do
     garden_info = Garden.info("VVCG\nVVRC")
     assert garden_info.bob == {:clover, :grass, :radishes, :clover}
   end
 
-  @tag :skip
+  @tag :pending
   test "gets the garden for all students" do
     garden_info = Garden.info("VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV")
     assert garden_info.alice == {:violets, :radishes, :violets, :radishes}
@@ -48,14 +48,14 @@ defmodule GardenTest do
     assert garden_info.larry == {:grass, :violets, :clover, :violets}
   end
 
-  @tag :skip
+  @tag :pending
   test "accepts custom child names" do
     garden_info = Garden.info("VC\nRC", [:nate, :maggie])
     assert garden_info.maggie == {:violets, :clover, :radishes, :clover}
     assert garden_info.nate == {}
   end
 
-  @tag :skip
+  @tag :pending
   test "gets the garden for all students with custom child names" do
     names = [:maggie, :nate, :xander, :ophelia, :pete, :reggie, :sylvia,
              :tanner, :ursula, :victor, :winnie, :ynold]

--- a/exercises/largest-series-product/largest_series_product_test.exs
+++ b/exercises/largest-series-product/largest_series_product_test.exs
@@ -3,91 +3,91 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule LargestSeriesProductTest do
   use ExUnit.Case
 
-  # @tag :skip
+  # @tag :pending
   test "largest product of 2" do
     assert Series.largest_product("0123456789", 2) == 72
   end
 
-  @tag :skip
+  @tag :pending
   test "largest product of a tiny number" do
     assert Series.largest_product("12", 2) == 2
   end
 
-  @tag :skip
+  @tag :pending
   test "another tiny number" do
     assert Series.largest_product("19", 2) == 9
   end
 
-  @tag :skip
+  @tag :pending
   test "largest product of 2 shuffled" do
     assert Series.largest_product("576802143", 2) == 48
   end
 
-  @tag :skip
+  @tag :pending
   test "largest product of 3" do
     assert Series.largest_product("0123456789", 3) == 504
   end
 
-  @tag :skip
+  @tag :pending
   test "largest product of 3 shuffled" do
     assert Series.largest_product("1027839564", 3) == 270
   end
 
-  @tag :skip
+  @tag :pending
   test "largest product of 5" do
     assert Series.largest_product("0123456789", 5) == 15120
   end
 
-  @tag :skip
+  @tag :pending
   test "some big number" do
     assert Series.largest_product("73167176531330624919225119674426574742355349194934", 6) == 23520
   end
 
-  @tag :skip
+  @tag :pending
   test "some other big number" do
     assert Series.largest_product("52677741234314237566414902593461595376319419139427", 6) == 28350
   end
 
-  @tag :skip
+  @tag :pending
   test "number with all zeroes" do
     assert Series.largest_product("0000", 2) == 0
   end
 
-  @tag :skip
+  @tag :pending
   test "number where all products are zero" do
     assert Series.largest_product("99099", 3) == 0
   end
 
-  @tag :skip
+  @tag :pending
   test "identity with empty string" do
     assert Series.largest_product("", 0) == 1
   end
 
-  @tag :skip
+  @tag :pending
   test "identity with non-empty string" do
     assert Series.largest_product("123", 0) == 1
   end
 
-  @tag :skip
+  @tag :pending
   test "raises if span is too large" do
     assert_raise ArgumentError, fn ->
       Series.largest_product("123", 4)
     end
   end
 
-  @tag :skip
+  @tag :pending
   test "raises with empty string but non-zero span size" do
     assert_raise ArgumentError, fn ->
       Series.largest_product("", 1)
     end
   end
 
-  @tag :skip
+  @tag :pending
   test "raises with non-empty string and negative span size" do
     assert_raise ArgumentError, fn ->
       Series.largest_product("1234", -1)

--- a/exercises/leap/leap_test.exs
+++ b/exercises/leap/leap_test.exs
@@ -3,27 +3,27 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule LeapTest do
   use ExUnit.Case
 
-  # @tag :skip
+  # @tag :pending
   test "vanilla leap year" do
     assert Year.leap_year?(1996)
   end
 
-  @tag :skip
+  @tag :pending
   test "any old year" do
     refute Year.leap_year?(1997), "1997 is not a leap year."
   end
 
-  @tag :skip
+  @tag :pending
   test "century" do
     refute Year.leap_year?(1900), "1900 is not a leap year."
   end
 
-  @tag :skip
+  @tag :pending
   test "exceptional century" do
     assert Year.leap_year?(2400)
   end

--- a/exercises/list-ops/list_ops_test.exs
+++ b/exercises/list-ops/list_ops_test.exs
@@ -3,7 +3,7 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule ListOpsTest do
   alias ListOps, as: L
@@ -12,132 +12,132 @@ defmodule ListOpsTest do
 
   defp odd?(n), do: rem(n, 2) == 1
 
-  # @tag :skip
+  # @tag :pending
   test "count of empty list" do
     assert L.count([]) == 0
   end
 
-  @tag :skip
+  @tag :pending
   test "count of normal list" do
     assert L.count([1,3,5,7]) == 4
   end
 
-  @tag :skip
+  @tag :pending
   test "count of huge list" do
     assert L.count(Enum.to_list(1..1_000_000)) == 1_000_000
   end
 
-  @tag :skip
+  @tag :pending
   test "reverse of empty list" do
     assert L.reverse([]) == []
   end
 
-  @tag :skip
+  @tag :pending
   test "reverse of normal list" do
     assert L.reverse([1,3,5,7]) == [7,5,3,1]
   end
 
-  @tag :skip
+  @tag :pending
   test "reverse of huge list" do
     assert L.reverse(Enum.to_list(1..1_000_000)) == Enum.to_list(1_000_000..1)
   end
 
-  @tag :skip
+  @tag :pending
   test "map of empty list" do
     assert L.map([], &(&1+1)) == []
   end
 
-  @tag :skip
+  @tag :pending
   test "map of normal list" do
     assert L.map([1,3,5,7], &(&1+1)) == [2,4,6,8]
   end
 
-  @tag :skip
+  @tag :pending
   test "map of huge list" do
     assert L.map(Enum.to_list(1..1_000_000), &(&1+1)) ==
       Enum.to_list(2..1_000_001)
   end
 
-  @tag :skip
+  @tag :pending
   test "filter of empty list" do
     assert L.filter([], &odd?/1) == []
   end
 
-  @tag :skip
+  @tag :pending
   test "filter of normal list" do
     assert L.filter([1,2,3,4], &odd?/1) == [1,3]
   end
 
-  @tag :skip
+  @tag :pending
   test "filter of huge list" do
     assert L.filter(Enum.to_list(1..1_000_000), &odd?/1) ==
       Enum.map(1..500_000, &(&1*2-1))
   end
 
-  @tag :skip
+  @tag :pending
   test "reduce of empty list" do
     assert L.reduce([], 0, &(&1+&2)) == 0
   end
 
-  @tag :skip
+  @tag :pending
   test "reduce of normal list" do
     assert L.reduce([1,2,3,4], -3, &(&1+&2)) == 7
   end
 
-  @tag :skip
+  @tag :pending
   test "reduce of huge list" do
     assert L.reduce(Enum.to_list(1..1_000_000), 0, &(&1+&2)) ==
       Enum.reduce(1..1_000_000, 0, &(&1+&2))
   end
 
-  @tag :skip
+  @tag :pending
   test "reduce with non-commutative function" do
     assert L.reduce([1,2,3,4], 10, fn x, acc -> acc - x end) == 0
   end
 
-  @tag :skip
+  @tag :pending
   test "append of empty lists" do
     assert L.append([], []) == []
   end
 
-  @tag :skip
+  @tag :pending
   test "append of empty and non-empty list" do
     assert L.append([], [1,2,3,4]) == [1,2,3,4]
   end
 
-  @tag :skip
+  @tag :pending
   test "append of non-empty and empty list" do
     assert L.append([1,2,3,4], []) == [1,2,3,4]
   end
 
-  @tag :skip
+  @tag :pending
   test "append of non-empty lists" do
     assert L.append([1,2,3], [4,5]) == [1,2,3,4,5]
   end
 
-  @tag :skip
+  @tag :pending
   test "append of huge lists" do
     assert L.append(Enum.to_list(1..1_000_000), Enum.to_list(1_000_001..2_000_000)) ==
       Enum.to_list(1..2_000_000)
   end
 
-  @tag :skip
+  @tag :pending
   test "concat of empty list of lists" do
     assert L.concat([]) == []
   end
 
-  @tag :skip
+  @tag :pending
   test "concat of normal list of lists" do
     assert L.concat([[1,2],[3],[],[4,5,6]]) == [1,2,3,4,5,6]
   end
 
-  @tag :skip
+  @tag :pending
   test "concat of huge list of small lists" do
     assert L.concat(Enum.map(1..1_000_000, &[&1])) ==
       Enum.to_list(1..1_000_000)
   end
 
-  @tag :skip
+  @tag :pending
   test "concat of small list of huge lists" do
     assert L.concat(Enum.map(0..9, &Enum.to_list((&1*100_000+1)..((&1+1)*100_000)))) ==
       Enum.to_list(1..1_000_000)

--- a/exercises/luhn/luhn_test.exs
+++ b/exercises/luhn/luhn_test.exs
@@ -3,7 +3,7 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule LuhnTest do
   use ExUnit.Case
@@ -12,32 +12,32 @@ defmodule LuhnTest do
     assert Luhn.checksum("4913") == 22
   end
 
-  @tag :skip
+  @tag :pending
   test "checksum again" do
     assert Luhn.checksum("201773") == 21
   end
 
-  @tag :skip
+  @tag :pending
   test "invalid number" do
     assert Luhn.valid?("738") == false
   end
 
-  @tag :skip
+  @tag :pending
   test "valid number" do
     assert Luhn.valid?("8739567") == true
   end
 
-  @tag :skip
+  @tag :pending
   test "create valid number" do
     assert Luhn.create("123") == "1230"
   end
 
-  @tag :skip
+  @tag :pending
   test "create other valid number" do
     assert Luhn.create("873956") == "8739567"
   end
 
-  @tag :skip
+  @tag :pending
   test "create yet another valid number" do
     assert Luhn.create("837263756") == "8372637564"
   end

--- a/exercises/markdown/markdown_test.exs
+++ b/exercises/markdown/markdown_test.exs
@@ -3,68 +3,68 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule MarkdownTest do
   use ExUnit.Case
 
-  # @tag :skip
+  # @tag :pending
   test "parses normal text as a paragraph" do
     input = "This will be a paragraph"
     expected = "<p>This will be a paragraph</p>"
     assert Markdown.parse(input) == expected
   end
 
-  @tag :skip
+  @tag :pending
   test "parsing italics" do
     input = "_This will be italic_"
     expected = "<p><em>This will be italic</em></p>"
     assert Markdown.parse(input) == expected
   end
 
-  @tag :skip
+  @tag :pending
   test "parsing bold text" do
     input = "__This will be bold__"
     expected = "<p><strong>This will be bold</strong></p>"
     assert Markdown.parse(input) == expected
   end
 
-  @tag :skip
+  @tag :pending
   test "mixed normal, italics and bold text" do
     input = "This will _be_ __mixed__"
     expected = "<p>This will <em>be</em> <strong>mixed</strong></p>"
     assert Markdown.parse(input) == expected
   end
 
-  @tag :skip
+  @tag :pending
   test "with h1 header level" do
     input = "# This will be an h1"
     expected = "<h1>This will be an h1</h1>"
     assert Markdown.parse(input) == expected
   end
 
-  @tag :skip
+  @tag :pending
   test "with h2 header level" do
     input = "## This will be an h2"
     expected = "<h2>This will be an h2</h2>"
     assert Markdown.parse(input) == expected
   end
 
-  @tag :skip
+  @tag :pending
   test "with h6 header level" do
     input = "###### This will be an h6"
     expected = "<h6>This will be an h6</h6>"
     assert Markdown.parse(input) == expected
   end
 
-  @tag :skip
+  @tag :pending
   test "unordered lists" do
     input = "* Item 1\n* Item 2"
     expected = "<ul><li>Item 1</li><li>Item 2</li></ul>"
     assert Markdown.parse(input) == expected
   end
 
-  @tag :skip
+  @tag :pending
   test "with a little bit of everything" do
     input = "# Header!\n* __Bold Item__\n* _Italic Item_"
     expected = "<h1>Header!</h1><ul><li><strong>Bold Item</strong></li><li><em>Italic Item</em></li></ul>"

--- a/exercises/meetup/meetup_test.exs
+++ b/exercises/meetup/meetup_test.exs
@@ -3,462 +3,462 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule MeetupTest do
   use ExUnit.Case
 
-  # @tag :skip
+  # @tag :pending
   test "monteenth of may 2013" do
     assert Meetup.meetup(2013, 5, :monday, :teenth) == {2013, 5, 13}
   end
 
-  @tag :skip
+  @tag :pending
   test "monteenth of august 2013" do
     assert Meetup.meetup(2013, 8, :monday, :teenth) == {2013, 8, 19}
   end
 
-  @tag :skip
+  @tag :pending
   test "monteenth of september 2013" do
     assert Meetup.meetup(2013, 9, :monday, :teenth) == {2013, 9, 16}
   end
 
-  @tag :skip
+  @tag :pending
   test "tuesteenth of march 2013" do
     assert Meetup.meetup(2013, 3, :tuesday, :teenth) == {2013, 3, 19}
   end
 
-  @tag :skip
+  @tag :pending
   test "tuesteenth of april 2013" do
     assert Meetup.meetup(2013, 4, :tuesday, :teenth) == {2013, 4, 16}
   end
 
-  @tag :skip
+  @tag :pending
   test "tuesteenth of august 2013" do
     assert Meetup.meetup(2013, 8, :tuesday, :teenth) == {2013, 8, 13}
   end
 
-  @tag :skip
+  @tag :pending
   test "wednesteenth of january 2013" do
     assert Meetup.meetup(2013, 1, :wednesday, :teenth) == {2013, 1, 16}
   end
 
-  @tag :skip
+  @tag :pending
   test "wednesteenth of february 2013" do
     assert Meetup.meetup(2013, 2, :wednesday, :teenth) == {2013, 2, 13}
   end
 
-  @tag :skip
+  @tag :pending
   test "wednesteenth of june 2013" do
     assert Meetup.meetup(2013, 6, :wednesday, :teenth) == {2013, 6, 19}
   end
 
-  @tag :skip
+  @tag :pending
   test "thursteenth of may 2013" do
     assert Meetup.meetup(2013, 5, :thursday, :teenth) == {2013, 5, 16}
   end
 
-  @tag :skip
+  @tag :pending
   test "thursteenth of june 2013" do
     assert Meetup.meetup(2013, 6, :thursday, :teenth) == {2013, 6, 13}
   end
 
-  @tag :skip
+  @tag :pending
   test "thursteenth of september 2013" do
     assert Meetup.meetup(2013, 9, :thursday, :teenth) == {2013, 9, 19}
   end
 
-  @tag :skip
+  @tag :pending
   test "friteenth of april 2013" do
     assert Meetup.meetup(2013, 4, :friday, :teenth) == {2013, 4, 19}
   end
 
-  @tag :skip
+  @tag :pending
   test "friteenth of august 2013" do
     assert Meetup.meetup(2013, 8, :friday, :teenth) == {2013, 8, 16}
   end
 
-  @tag :skip
+  @tag :pending
   test "friteenth of september 2013" do
     assert Meetup.meetup(2013, 9, :friday, :teenth) == {2013, 9, 13}
   end
 
-  @tag :skip
+  @tag :pending
   test "saturteenth of february 2013" do
     assert Meetup.meetup(2013, 2, :saturday, :teenth) == {2013, 2, 16}
   end
 
-  @tag :skip
+  @tag :pending
   test "saturteenth of april 2013" do
     assert Meetup.meetup(2013, 4, :saturday, :teenth) == {2013, 4, 13}
   end
 
-  @tag :skip
+  @tag :pending
   test "saturteenth of october 2013" do
     assert Meetup.meetup(2013, 10, :saturday, :teenth) == {2013, 10, 19}
   end
 
-  @tag :skip
+  @tag :pending
   test "sunteenth of may 2013" do
     assert Meetup.meetup(2013, 5, :sunday, :teenth) == {2013, 5, 19}
   end
 
-  @tag :skip
+  @tag :pending
   test "sunteenth of june 2013" do
     assert Meetup.meetup(2013, 6, :sunday, :teenth) == {2013, 6, 16}
   end
 
-  @tag :skip
+  @tag :pending
   test "sunteenth of october 2013" do
     assert Meetup.meetup(2013, 10, :sunday, :teenth) == {2013, 10, 13}
   end
 
-  @tag :skip
+  @tag :pending
   test "first monday of march 2013" do
     assert Meetup.meetup(2013, 3, :monday, :first) == {2013, 3, 4}
   end
 
-  @tag :skip
+  @tag :pending
   test "first monday of april 2013" do
     assert Meetup.meetup(2013, 4, :monday, :first) == {2013, 4, 1}
   end
 
-  @tag :skip
+  @tag :pending
   test "first tuesday of may 2013" do
     assert Meetup.meetup(2013, 5, :tuesday, :first) == {2013, 5, 7}
   end
 
-  @tag :skip
+  @tag :pending
   test "first tuesday of june 2013" do
     assert Meetup.meetup(2013, 6, :tuesday, :first) == {2013, 6, 4}
   end
 
-  @tag :skip
+  @tag :pending
   test "first wednesday of july 2013" do
     assert Meetup.meetup(2013, 7, :wednesday, :first) == {2013, 7, 3}
   end
 
-  @tag :skip
+  @tag :pending
   test "first wednesday of august 2013" do
     assert Meetup.meetup(2013, 8, :wednesday, :first) == {2013, 8, 7}
   end
 
-  @tag :skip
+  @tag :pending
   test "first thursday of september 2013" do
     assert Meetup.meetup(2013, 9, :thursday, :first) == {2013, 9, 5}
   end
 
-  @tag :skip
+  @tag :pending
   test "first thursday of october 2013" do
     assert Meetup.meetup(2013, 10, :thursday, :first) == {2013, 10, 3}
   end
 
-  @tag :skip
+  @tag :pending
   test "first friday of november 2013" do
     assert Meetup.meetup(2013, 11, :friday, :first) == {2013, 11, 1}
   end
 
-  @tag :skip
+  @tag :pending
   test "first friday of december 2013" do
     assert Meetup.meetup(2013, 12, :friday, :first) == {2013, 12, 6}
   end
 
-  @tag :skip
+  @tag :pending
   test "first saturday of january 2013" do
     assert Meetup.meetup(2013, 1, :saturday, :first) == {2013, 1, 5}
   end
 
-  @tag :skip
+  @tag :pending
   test "first saturday of february 2013" do
     assert Meetup.meetup(2013, 2, :saturday, :first) == {2013, 2, 2}
   end
 
-  @tag :skip
+  @tag :pending
   test "first sunday of march 2013" do
     assert Meetup.meetup(2013, 3, :sunday, :first) == {2013, 3, 3}
   end
 
-  @tag :skip
+  @tag :pending
   test "first sunday of april 2013" do
     assert Meetup.meetup(2013, 4, :sunday, :first) == {2013, 4, 7}
   end
 
-  @tag :skip
+  @tag :pending
   test "second monday of march 2013" do
     assert Meetup.meetup(2013, 3, :monday, :second) == {2013, 3, 11}
   end
 
-  @tag :skip
+  @tag :pending
   test "second monday of april 2013" do
     assert Meetup.meetup(2013, 4, :monday, :second) == {2013, 4, 8}
   end
 
-  @tag :skip
+  @tag :pending
   test "second tuesday of may 2013" do
     assert Meetup.meetup(2013, 5, :tuesday, :second) == {2013, 5, 14}
   end
 
-  @tag :skip
+  @tag :pending
   test "second tuesday of june 2013" do
     assert Meetup.meetup(2013, 6, :tuesday, :second) == {2013, 6, 11}
   end
 
-  @tag :skip
+  @tag :pending
   test "second wednesday of july 2013" do
     assert Meetup.meetup(2013, 7, :wednesday, :second) == {2013, 7, 10}
   end
 
-  @tag :skip
+  @tag :pending
   test "second wednesday of august 2013" do
     assert Meetup.meetup(2013, 8, :wednesday, :second) == {2013, 8, 14}
   end
 
-  @tag :skip
+  @tag :pending
   test "second thursday of september 2013" do
     assert Meetup.meetup(2013, 9, :thursday, :second) == {2013, 9, 12}
   end
 
-  @tag :skip
+  @tag :pending
   test "second thursday of october 2013" do
     assert Meetup.meetup(2013, 10, :thursday, :second) == {2013, 10, 10}
   end
 
-  @tag :skip
+  @tag :pending
   test "second friday of november 2013" do
     assert Meetup.meetup(2013, 11, :friday, :second) == {2013, 11, 8}
   end
 
-  @tag :skip
+  @tag :pending
   test "second friday of december 2013" do
     assert Meetup.meetup(2013, 12, :friday, :second) == {2013, 12, 13}
   end
 
-  @tag :skip
+  @tag :pending
   test "second saturday of january 2013" do
     assert Meetup.meetup(2013, 1, :saturday, :second) == {2013, 1, 12}
   end
 
-  @tag :skip
+  @tag :pending
   test "second saturday of february 2013" do
     assert Meetup.meetup(2013, 2, :saturday, :second) == {2013, 2, 9}
   end
 
-  @tag :skip
+  @tag :pending
   test "second sunday of march 2013" do
     assert Meetup.meetup(2013, 3, :sunday, :second) == {2013, 3, 10}
   end
 
-  @tag :skip
+  @tag :pending
   test "second sunday of april 2013" do
     assert Meetup.meetup(2013, 4, :sunday, :second) == {2013, 4, 14}
   end
 
-  @tag :skip
+  @tag :pending
   test "third monday of march 2013" do
     assert Meetup.meetup(2013, 3, :monday, :third) == {2013, 3, 18}
   end
 
-  @tag :skip
+  @tag :pending
   test "third monday of april 2013" do
     assert Meetup.meetup(2013, 4, :monday, :third) == {2013, 4, 15}
   end
 
-  @tag :skip
+  @tag :pending
   test "third tuesday of may 2013" do
     assert Meetup.meetup(2013, 5, :tuesday, :third) == {2013, 5, 21}
   end
 
-  @tag :skip
+  @tag :pending
   test "third tuesday of june 2013" do
     assert Meetup.meetup(2013, 6, :tuesday, :third) == {2013, 6, 18}
   end
 
-  @tag :skip
+  @tag :pending
   test "third wednesday of july 2013" do
     assert Meetup.meetup(2013, 7, :wednesday, :third) == {2013, 7, 17}
   end
 
-  @tag :skip
+  @tag :pending
   test "third wednesday of august 2013" do
     assert Meetup.meetup(2013, 8, :wednesday, :third) == {2013, 8, 21}
   end
 
-  @tag :skip
+  @tag :pending
   test "third thursday of september 2013" do
     assert Meetup.meetup(2013, 9, :thursday, :third) == {2013, 9, 19}
   end
 
-  @tag :skip
+  @tag :pending
   test "third thursday of october 2013" do
     assert Meetup.meetup(2013, 10, :thursday, :third) == {2013, 10, 17}
   end
 
-  @tag :skip
+  @tag :pending
   test "third friday of november 2013" do
     assert Meetup.meetup(2013, 11, :friday, :third) == {2013, 11, 15}
   end
 
-  @tag :skip
+  @tag :pending
   test "third friday of december 2013" do
     assert Meetup.meetup(2013, 12, :friday, :third) == {2013, 12, 20}
   end
 
-  @tag :skip
+  @tag :pending
   test "third saturday of january 2013" do
     assert Meetup.meetup(2013, 1, :saturday, :third) == {2013, 1, 19}
   end
 
-  @tag :skip
+  @tag :pending
   test "third saturday of february 2013" do
     assert Meetup.meetup(2013, 2, :saturday, :third) == {2013, 2, 16}
   end
 
-  @tag :skip
+  @tag :pending
   test "third sunday of march 2013" do
     assert Meetup.meetup(2013, 3, :sunday, :third) == {2013, 3, 17}
   end
 
-  @tag :skip
+  @tag :pending
   test "third sunday of april 2013" do
     assert Meetup.meetup(2013, 4, :sunday, :third) == {2013, 4, 21}
   end
 
-  @tag :skip
+  @tag :pending
   test "fourth monday of march 2013" do
     assert Meetup.meetup(2013, 3, :monday, :fourth) == {2013, 3, 25}
   end
 
-  @tag :skip
+  @tag :pending
   test "fourth monday of april 2013" do
     assert Meetup.meetup(2013, 4, :monday, :fourth) == {2013, 4, 22}
   end
 
-  @tag :skip
+  @tag :pending
   test "fourth tuesday of may 2013" do
     assert Meetup.meetup(2013, 5, :tuesday, :fourth) == {2013, 5, 28}
   end
 
-  @tag :skip
+  @tag :pending
   test "fourth tuesday of june 2013" do
     assert Meetup.meetup(2013, 6, :tuesday, :fourth) == {2013, 6, 25}
   end
 
-  @tag :skip
+  @tag :pending
   test "fourth wednesday of july 2013" do
     assert Meetup.meetup(2013, 7, :wednesday, :fourth) == {2013, 7, 24}
   end
 
-  @tag :skip
+  @tag :pending
   test "fourth wednesday of august 2013" do
     assert Meetup.meetup(2013, 8, :wednesday, :fourth) == {2013, 8, 28}
   end
 
-  @tag :skip
+  @tag :pending
   test "fourth thursday of september 2013" do
     assert Meetup.meetup(2013, 9, :thursday, :fourth) == {2013, 9, 26}
   end
 
-  @tag :skip
+  @tag :pending
   test "fourth thursday of october 2013" do
     assert Meetup.meetup(2013, 10, :thursday, :fourth) == {2013, 10, 24}
   end
 
-  @tag :skip
+  @tag :pending
   test "fourth friday of november 2013" do
     assert Meetup.meetup(2013, 11, :friday, :fourth) == {2013, 11, 22}
   end
 
-  @tag :skip
+  @tag :pending
   test "fourth friday of december 2013" do
     assert Meetup.meetup(2013, 12, :friday, :fourth) == {2013, 12, 27}
   end
 
-  @tag :skip
+  @tag :pending
   test "fourth saturday of january 2013" do
     assert Meetup.meetup(2013, 1, :saturday, :fourth) == {2013, 1, 26}
   end
 
-  @tag :skip
+  @tag :pending
   test "fourth saturday of february 2013" do
     assert Meetup.meetup(2013, 2, :saturday, :fourth) == {2013, 2, 23}
   end
 
-  @tag :skip
+  @tag :pending
   test "fourth sunday of march 2013" do
     assert Meetup.meetup(2013, 3, :sunday, :fourth) == {2013, 3, 24}
   end
 
-  @tag :skip
+  @tag :pending
   test "fourth sunday of april 2013" do
     assert Meetup.meetup(2013, 4, :sunday, :fourth) == {2013, 4, 28}
   end
 
-  @tag :skip
+  @tag :pending
   test "last monday of march 2013" do
     assert Meetup.meetup(2013, 3, :monday, :last) == {2013, 3, 25}
   end
 
-  @tag :skip
+  @tag :pending
   test "last monday of april 2013" do
     assert Meetup.meetup(2013, 4, :monday, :last) == {2013, 4, 29}
   end
 
-  @tag :skip
+  @tag :pending
   test "last tuesday of may 2013" do
     assert Meetup.meetup(2013, 5, :tuesday, :last) == {2013, 5, 28}
   end
 
-  @tag :skip
+  @tag :pending
   test "last tuesday of june 2013" do
     assert Meetup.meetup(2013, 6, :tuesday, :last) == {2013, 6, 25}
   end
 
-  @tag :skip
+  @tag :pending
   test "last wednesday of july 2013" do
     assert Meetup.meetup(2013, 7, :wednesday, :last) == {2013, 7, 31}
   end
 
-  @tag :skip
+  @tag :pending
   test "last wednesday of august 2013" do
     assert Meetup.meetup(2013, 8, :wednesday, :last) == {2013, 8, 28}
   end
 
-  @tag :skip
+  @tag :pending
   test "last thursday of september 2013" do
     assert Meetup.meetup(2013, 9, :thursday, :last) == {2013, 9, 26}
   end
 
-  @tag :skip
+  @tag :pending
   test "last thursday of october 2013" do
     assert Meetup.meetup(2013, 10, :thursday, :last) == {2013, 10, 31}
   end
 
-  @tag :skip
+  @tag :pending
   test "last friday of november 2013" do
     assert Meetup.meetup(2013, 11, :friday, :last) == {2013, 11, 29}
   end
 
-  @tag :skip
+  @tag :pending
   test "last friday of december 2013" do
     assert Meetup.meetup(2013, 12, :friday, :last) == {2013, 12, 27}
   end
 
-  @tag :skip
+  @tag :pending
   test "last saturday of january 2013" do
     assert Meetup.meetup(2013, 1, :saturday, :last) == {2013, 1, 26}
   end
 
-  @tag :skip
+  @tag :pending
   test "last saturday of february 2013" do
     assert Meetup.meetup(2013, 2, :saturday, :last) == {2013, 2, 23}
   end
 
-  @tag :skip
+  @tag :pending
   test "last sunday of march 2013" do
     assert Meetup.meetup(2013, 3, :sunday, :last) == {2013, 3, 31}
   end
 
-  @tag :skip
+  @tag :pending
   test "last sunday of april 2013" do
     assert Meetup.meetup(2013, 4, :sunday, :last) == {2013, 4, 28}
   end

--- a/exercises/minesweeper/minesweeper_test.exs
+++ b/exercises/minesweeper/minesweeper_test.exs
@@ -3,20 +3,20 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule MinesweeperTest do
   use ExUnit.Case
 
   defp clean(b), do: Enum.map(b, &String.replace(&1, ~r/[^*]/, " "))
 
-  # @tag :skip
+  # @tag :pending
   test "zero size board" do
     b = []
     assert Minesweeper.annotate(clean(b)) == b
   end
 
-  @tag :skip
+  @tag :pending
   test "empty board" do
     b = ["   ",
          "   ",
@@ -24,7 +24,7 @@ defmodule MinesweeperTest do
     assert Minesweeper.annotate(clean(b)) == b
   end
 
-  @tag :skip
+  @tag :pending
   test "board full of mines" do
     b = ["***",
          "***",
@@ -32,7 +32,7 @@ defmodule MinesweeperTest do
     assert Minesweeper.annotate(clean(b)) == b
   end
 
-  @tag :skip
+  @tag :pending
   test "surrounded" do
     b = ["***",
          "*8*",
@@ -40,13 +40,13 @@ defmodule MinesweeperTest do
     assert Minesweeper.annotate(clean(b)) == b
   end
 
-  @tag :skip
+  @tag :pending
   test "horizontal line" do
     b = ["1*2*1"]
     assert Minesweeper.annotate(clean(b)) == b
   end
 
-  @tag :skip
+  @tag :pending
   test "vertical line" do
     b = ["1",
          "*",
@@ -56,7 +56,7 @@ defmodule MinesweeperTest do
     assert Minesweeper.annotate(clean(b)) == b
   end
 
-  @tag :skip
+  @tag :pending
   test "cross" do
     b = [" 2*2 ",
          "25*52",

--- a/exercises/nth-prime/nth_prime_test.exs
+++ b/exercises/nth-prime/nth_prime_test.exs
@@ -3,32 +3,32 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule NthPrimeTest do
   use ExUnit.Case
 
-  # @tag :skip
+  # @tag :pending
   test "first prime" do
     assert Prime.nth(1) == 2
   end
 
-  @tag :skip
+  @tag :pending
   test "second prime" do
     assert Prime.nth(2) == 3
   end
 
-  @tag :skip
+  @tag :pending
   test "sixth prime" do
     assert Prime.nth(6) == 13
   end
 
-  @tag :skip
+  @tag :pending
   test "100th prime" do
     assert Prime.nth(100) == 541
   end
 
-  @tag :skip
+  @tag :pending
   test "weird case" do
     catch_error Prime.nth(0)
   end

--- a/exercises/nucleotide-count/nucleotide_count_test.exs
+++ b/exercises/nucleotide-count/nucleotide_count_test.exs
@@ -3,39 +3,39 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule NucleotideCountTest do
   use ExUnit.Case
 
-  # @tag :skip
+  # @tag :pending
   test "empty dna string has no adenosine" do
     assert NucleotideCount.count('', ?A) == 0
   end
 
-  @tag :skip
+  @tag :pending
   test "repetitive cytidine gets counted" do
     assert NucleotideCount.count('CCCCC', ?C) == 5
   end
 
-  @tag :skip
+  @tag :pending
   test "counts only thymidine" do
     assert NucleotideCount.count('GGGGGTAACCCGG', ?T) == 1
   end
 
-  @tag :skip
+  @tag :pending
   test "empty dna string has no nucleotides" do
     expected = %{?A => 0, ?T => 0, ?C => 0, ?G => 0}
     assert NucleotideCount.histogram('') == expected
   end
 
-  @tag :skip
+  @tag :pending
   test "repetitive sequence has only guanosine" do
     expected = %{?A => 0, ?T => 0, ?C => 0, ?G => 8}
     assert NucleotideCount.histogram('GGGGGGGG') == expected
   end
 
-  @tag :skip
+  @tag :pending
   test "counts all nucleotides" do
     s = 'AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC'
     expected = %{?A => 20, ?T => 21, ?C => 12, ?G => 17}

--- a/exercises/palindrome-products/palindrome_products_test.exs
+++ b/exercises/palindrome-products/palindrome_products_test.exs
@@ -3,40 +3,40 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule PalindromeProductsTest do
   use ExUnit.Case
 
-  # @tag :skip
+  # @tag :pending
   test "largest palindrome from single digit factors" do
     palindromes = Palindromes.generate(9)
     assert (palindromes |> Map.keys |> Enum.sort |> List.last) == 9
     assert Enum.sort(palindromes[9]) == [[1, 9], [3, 3]]
   end
 
-  @tag :skip
+  @tag :pending
   test "largest palindrome from double digit factors" do
     palindromes = Palindromes.generate(99, 10)
     assert (palindromes |> Map.keys |> Enum.sort |> List.last) == 9009
     assert palindromes[9009] == [[91, 99]]
   end
 
-  @tag :skip
+  @tag :pending
   test "smallest palindrome from double digit factors" do
     palindromes = Palindromes.generate(99, 10)
     assert (palindromes |> Map.keys |> Enum.sort |> hd) == 121
     assert palindromes[121] == [[11, 11]]
   end
 
-  @tag :skip
+  @tag :pending
   test "largest palindrome from triple digit factors" do
     palindromes = Palindromes.generate(999, 100)
     assert (palindromes |> Map.keys |> Enum.sort |> List.last) == 906609
     assert palindromes[906609] == [[913, 993]]
   end
 
-  @tag :skip
+  @tag :pending
   test "smallest palindromes from triple digit factors" do
     palindromes = Palindromes.generate(999, 100)
     assert (palindromes |> Map.keys |> Enum.sort |> hd) == 10201

--- a/exercises/pangram/pangram_test.exs
+++ b/exercises/pangram/pangram_test.exs
@@ -3,57 +3,57 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule PangramTest do
   use ExUnit.Case
 
-  # @tag :skip
+  # @tag :pending
   test "empty sentence" do
     refute Pangram.pangram?("")
   end
 
-  @tag :skip
+  @tag :pending
   test "pangram with only lower case" do
     assert Pangram.pangram?("the quick brown fox jumps over the lazy dog")
   end
 
-  @tag :skip
+  @tag :pending
   test "missing character 'x'" do
     refute Pangram.pangram?("a quick movement of the enemy will jeopardize five gunboats")
   end
 
-  @tag :skip
+  @tag :pending
   test "another missing character 'x'" do
     refute Pangram.pangram?("the quick brown fish jumps over the lazy dog")
   end
 
-  @tag :skip
+  @tag :pending
   test "pangram with underscores" do
     assert Pangram.pangram?("the_quick_brown_fox_jumps_over_the_lazy_dog")
   end
 
-  @tag :skip
+  @tag :pending
   test "pangram with numbers" do
     assert Pangram.pangram?("the 1 quick brown fox jumps over the 2 lazy dogs")
   end
 
-  @tag :skip
+  @tag :pending
   test "missing letters replaced by numbers" do
     refute Pangram.pangram?("7h3 qu1ck brown fox jumps ov3r 7h3 lazy dog")
   end
 
-  @tag :skip
+  @tag :pending
   test "pangram with mixed case and punctuation" do
     assert Pangram.pangram?("Five quacking Zephyrs jolt my wax bed.")
   end
 
-  @tag :skip
+  @tag :pending
   test "pangram with non ascii characters" do
     assert Pangram.pangram?("Victor jagt zwölf Boxkämpfer quer über den großen Sylter Deich.")
   end
 
-  @tag :skip
+  @tag :pending
   test "pangram in alphabet other than ASCII" do
     refute Pangram.pangram?("Широкая электрификация южных губерний даст мощный толчок подъёму сельского хозяйства.")
   end

--- a/exercises/parallel-letter-frequency/parallel_letter_frequency_test.exs
+++ b/exercises/parallel-letter-frequency/parallel_letter_frequency_test.exs
@@ -3,7 +3,7 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 # Your code should contain a frequency(texts, workers) function which accepts a
 # list of texts and the number of workers to use in parallel.
@@ -54,43 +54,43 @@ defmodule FrequencyTest do
     Frequency.frequency(texts, workers) |> Enum.sort() |> Enum.into(%{})
   end
 
-  # @tag :skip
+  # @tag :pending
   test "no texts mean no letters" do
     assert freq([]) == %{}
   end
 
-  @tag :skip
+  @tag :pending
   test "one letter" do
     assert freq(["a"]) == %{"a" => 1}
   end
 
-  @tag :skip
+  @tag :pending
   test "case insensitivity" do
     assert freq(["aA"]) == %{"a" => 2}
   end
 
-  @tag :skip
+  @tag :pending
   test "many empty texts still mean no letters" do
     assert freq(List.duplicate("  ", 10000)) == %{}
   end
 
-  @tag :skip
+  @tag :pending
   test "many times the same text gives a predictable result" do
     assert freq(List.duplicate("abc", 1000))
          == %{"a" => 1000, "b" => 1000, "c" => 1000}
   end
 
-  @tag :skip
+  @tag :pending
   test "punctuation doesn't count" do
     assert freq([@ode_an_die_freude])[","] == nil
   end
 
-  @tag :skip
+  @tag :pending
   test "numbers don't count" do
     assert freq(["Testing, 1, 2, 3"])["1"] == nil
   end
 
-  @tag :skip
+  @tag :pending
   test "all three anthems, together, 1 worker" do
     freqs = freq([@ode_an_die_freude, @wilhelmus, @star_spangled_banner], 1)
     assert freqs["a"] == 49
@@ -98,7 +98,7 @@ defmodule FrequencyTest do
     assert freqs["ü"] == 2
   end
 
-  @tag :skip
+  @tag :pending
   test "all three anthems, together, 4 workers" do
     freqs = freq([@ode_an_die_freude, @wilhelmus, @star_spangled_banner], 4)
     assert freqs["a"] == 49

--- a/exercises/pascals-triangle/pascals_triangle_test.exs
+++ b/exercises/pascals-triangle/pascals_triangle_test.exs
@@ -4,37 +4,37 @@ end
 
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule PascalsTriangleTest do
   use ExUnit.Case
 
-  # @tag :skip
+  # @tag pending
   test "one row" do
     assert PascalsTriangle.rows(1) == [[1]]
   end
 
-  @tag :skip
+  @tag :pending
   test "two rows" do
     assert PascalsTriangle.rows(2) == [[1], [1, 1]]
   end
 
-  @tag :skip
+  @tag :pending
   test "three rows" do
     assert PascalsTriangle.rows(3) == [[1], [1, 1], [1, 2, 1]]
   end
 
-  @tag :skip
+  @tag :pending
   test "fourth row" do
     assert List.last(PascalsTriangle.rows(4)) ==  [1, 3, 3, 1]
   end
 
-  @tag :skip
+  @tag :pending
   test "fifth row" do
     assert List.last(PascalsTriangle.rows(5)) ==  [1, 4, 6, 4, 1]
   end
 
-  @tag :skip
+  @tag :pending
   test "twentieth row" do
     expected = [
       1, 19, 171, 969, 3876, 11_628, 27_132, 50_388, 75_582, 92_378, 92_378,

--- a/exercises/phone-number/phone_number_test.exs
+++ b/exercises/phone-number/phone_number_test.exs
@@ -3,7 +3,7 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule PhoneTest do
   use ExUnit.Case
@@ -12,47 +12,47 @@ defmodule PhoneTest do
     assert Phone.number("(123) 456-7890") == "1234567890"
   end
 
-  @tag :skip
+  @tag :pending
   test "cleans number with dots" do
     assert Phone.number("123.456.7890") == "1234567890"
   end
 
-  @tag :skip
+  @tag :pending
   test "valid when 11 digits and first is 1" do
     assert Phone.number("11234567890") == "1234567890"
   end
 
-  @tag :skip
+  @tag :pending
   test "invalid when 11 digits" do
     assert Phone.number("21234567890") == "0000000000"
   end
 
-  @tag :skip
+  @tag :pending
   test "invalid when 9 digits" do
     assert Phone.number("123456789") == "0000000000"
   end
 
-  @tag :skip
+  @tag :pending
   test "invalid when proper number of digits but letters mixed in" do
     assert Phone.number("1a2a3a4a5a6a7a8a9a0a") == "0000000000"
   end
 
-  @tag :skip
+  @tag :pending
   test "area code" do
     assert Phone.area_code("1234567890") == "123"
   end
 
-  @tag :skip
+  @tag :pending
   test "area code with full US phone number" do
     assert Phone.area_code("11234567890") == "123"
   end
 
-  @tag :skip
+  @tag :pending
   test "pretty print" do
     assert Phone.pretty("1234567890") == "(123) 456-7890"
   end
 
-  @tag :skip
+  @tag :pending
   test "pretty print with full US phone number" do
     assert Phone.pretty("11234567890") == "(123) 456-7890"
   end

--- a/exercises/prime-factors/prime_factors_test.exs
+++ b/exercises/prime-factors/prime_factors_test.exs
@@ -3,67 +3,67 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule PrimeFactorsTest do
   use ExUnit.Case
 
-  # @tag :skip
+  # @tag :pending
   test "1" do
     assert PrimeFactors.factors_for(1) == []
   end
 
-  @tag :skip
+  @tag :pending
   test "2" do
     assert PrimeFactors.factors_for(2) == [2]
   end
 
-  @tag :skip
+  @tag :pending
   test "3" do
     assert PrimeFactors.factors_for(3) == [3]
   end
 
-  @tag :skip
+  @tag :pending
   test "4" do
     assert PrimeFactors.factors_for(4) == [2, 2]
   end
 
-  @tag :skip
+  @tag :pending
   test "6" do
     assert PrimeFactors.factors_for(6) == [2, 3]
   end
 
-  @tag :skip
+  @tag :pending
   test "8" do
     assert PrimeFactors.factors_for(8) == [2, 2, 2]
   end
 
-  @tag :skip
+  @tag :pending
   test "9" do
     assert PrimeFactors.factors_for(9) == [3, 3]
   end
 
-  @tag :skip
+  @tag :pending
   test "27" do
     assert PrimeFactors.factors_for(27) == [3, 3, 3]
   end
 
-  @tag :skip
+  @tag :pending
   test "625" do
     assert PrimeFactors.factors_for(625) == [5, 5, 5, 5]
   end
 
-  @tag :skip
+  @tag :pending
   test "901255" do
     assert PrimeFactors.factors_for(901255) == [5, 17, 23, 461]
   end
 
-  @tag :skip
+  @tag :pending
   test "93819012551" do
     assert PrimeFactors.factors_for(93819012551) == [11, 9539, 894119]
   end
 
-  @tag :skip
+  @tag :pending
   # @tag timeout: 2000
   #
   # The timeout tag above will set the below test to fail unless it completes

--- a/exercises/pythagorean-triplet/pythagorean_triplet_test.exs
+++ b/exercises/pythagorean-triplet/pythagorean_triplet_test.exs
@@ -3,48 +3,48 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule PythagoreanTripletTest do
   use ExUnit.Case
 
-  # @tag :skip
+  # @tag :pending
   test "sum" do
     triplet = [3, 4, 5]
     assert Triplet.sum(triplet) == 12
   end
 
-  @tag :skip
+  @tag :pending
   test "product" do
     triplet = [3, 4, 5]
     assert Triplet.product(triplet) == 60
   end
 
-  @tag :skip
+  @tag :pending
   test "pythagorean" do
     triplet = [3, 4, 5]
     assert Triplet.pythagorean?(triplet)
   end
 
-  @tag :skip
+  @tag :pending
   test "not pythagorean" do
     triplet = [5, 6, 7]
     refute Triplet.pythagorean?(triplet)
   end
 
-  @tag :skip
+  @tag :pending
   test "triplets up to 10" do
     triplets = Triplet.generate(1, 10)
     assert Enum.map(triplets, &Triplet.product/1) == [60, 480]
   end
 
-  @tag :skip
+  @tag :pending
   test "triplets from 11 up to 20" do
     triplets = Triplet.generate(11, 20)
     assert Enum.map(triplets, &Triplet.product/1) == [3840]
   end
 
-  @tag :skip
+  @tag :pending
   test "triplets where sum is 180 and max factor is 100" do
     triplets = Triplet.generate(1, 100, 180)
     assert Enum.map(triplets, &Triplet.product/1) == [118080, 168480, 202500]

--- a/exercises/queen-attack/queen_attack_test.exs
+++ b/exercises/queen-attack/queen_attack_test.exs
@@ -3,33 +3,33 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule QueenAttackTest do
   use ExUnit.Case
 
-  # @tag :skip
+  # @tag :pending
   test "default positions" do
     queens = Queens.new
     assert queens.white == {0, 3}
     assert queens.black == {7, 3}
   end
 
-  @tag :skip
+  @tag :pending
   test "specific placement" do
     queens = Queens.new({3, 7}, {6, 1})
     assert queens.white == {3, 7}
     assert queens.black == {6, 1}
   end
 
-  @tag :skip
+  @tag :pending
   test "cannot occupy same space" do
     assert_raise ArgumentError, fn ->
       Queens.new({2, 4}, {2, 4})
     end
   end
 
-  @tag :skip
+  @tag :pending
   test "string representation" do
     queens = Queens.new({2, 4}, {6, 6})
     board = String.strip """
@@ -45,7 +45,7 @@ _ _ _ _ _ _ _ _
     assert Queens.to_string(queens) == board
   end
 
-  @tag :skip
+  @tag :pending
   test "another string representation" do
     queens = Queens.new({7, 1}, {0, 0})
     board = String.strip """
@@ -61,7 +61,7 @@ _ W _ _ _ _ _ _
     assert Queens.to_string(queens) == board
   end
 
-  @tag :skip
+  @tag :pending
   test "yet another string representation" do
     queens = Queens.new({4, 3}, {3, 4})
     board = String.strip """
@@ -77,7 +77,7 @@ _ _ _ _ _ _ _ _
     assert Queens.to_string(queens) == board
   end
 
-  @tag :skip
+  @tag :pending
   test "queen placed on the bottom right corner" do
     queens = Queens.new({4, 3}, {7, 7})
     board = String.strip """
@@ -93,7 +93,7 @@ _ _ _ _ _ _ _ B
     assert Queens.to_string(queens) == board
   end
 
-  @tag :skip
+  @tag :pending
   test "queen placed on the edge of the board" do
     queens = Queens.new({4, 3}, {2, 7})
     board = String.strip """
@@ -109,43 +109,43 @@ _ _ _ _ _ _ _ _
     assert Queens.to_string(queens) == board
   end
 
-  @tag :skip
+  @tag :pending
   test "cannot attack" do
     queens = Queens.new({2, 3}, {4, 7})
     refute Queens.can_attack?(queens)
   end
 
-  @tag :skip
+  @tag :pending
   test "can attack on same row" do
     queens = Queens.new({2, 4}, {2, 7})
     assert Queens.can_attack?(queens)
   end
 
-  @tag :skip
+  @tag :pending
   test "can attack on same column" do
     queens = Queens.new({5, 4}, {2, 4})
     assert Queens.can_attack?(queens)
   end
 
-  @tag :skip
+  @tag :pending
   test "can attack on diagonal" do
     queens = Queens.new({1, 1}, {6, 6})
     assert Queens.can_attack?(queens)
   end
 
-  @tag :skip
+  @tag :pending
   test "can attack on other diagonal" do
     queens = Queens.new({0, 6}, {1, 7})
     assert Queens.can_attack?(queens)
   end
 
-  @tag :skip
+  @tag :pending
   test "can attack on yet another diagonal" do
     queens = Queens.new({4, 1}, {6, 3})
     assert Queens.can_attack?(queens)
   end
 
-  @tag :skip
+  @tag :pending
   test "can attack on a diagonal slanted the other way" do
     queens = Queens.new({6, 1}, {1, 6})
     assert Queens.can_attack?(queens)

--- a/exercises/rail-fence-cipher/rail_fence_cipher_test.exs
+++ b/exercises/rail-fence-cipher/rail_fence_cipher_test.exs
@@ -3,74 +3,74 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule RailFenceCipherTest do
   use ExUnit.Case
 
-  # @tag :skip
+  # @tag :pending
   test "encode with ending at the first rail" do
     assert RailFenceCipher.encode("XOXOXOXOXOXOXOXOXO", 2) == "XXXXXXXXXOOOOOOOOO"
   end
 
-  @tag :skip
+  @tag :pending
   test "encode with ending in the middle" do
     msg = "WEAREDISCOVEREDFLEEATONCE"
     assert RailFenceCipher.encode(msg, 3) == "WECRLTEERDSOEEFEAOCAIVDEN"
   end
 
-  @tag :skip
+  @tag :pending
   test "encode empty string" do
     assert RailFenceCipher.encode("", 4) == ""
   end
 
-  @tag :skip
+  @tag :pending
   test "encode a more diverse text" do
     msg = "The quick brown fox jumps over the lazy dog."
     cipher = "Tioxs aghucrwo p rtlzo.eqkbnfjmoeh yd   uve "
     assert RailFenceCipher.encode(msg, 4) == cipher
   end
 
-  @tag :skip
+  @tag :pending
   test "encode with one rail" do
     msg = "One rail, only one rail"
     assert RailFenceCipher.encode(msg, 1) == msg
   end
 
-  @tag :skip
+  @tag :pending
   test "encode letters of less than rails" do
     msg = "More rails than letters"
     assert RailFenceCipher.encode(msg, 24) == msg
   end
 
-  @tag :skip
+  @tag :pending
   test "decode full zigzag cipher" do
     cipher = "TEITELHDVLSNHDTIEIIEA"
     assert RailFenceCipher.decode(cipher, 3) == "THEDEVILISINTHEDETAIL"
   end
 
-  @tag :skip
+  @tag :pending
   test "decode with ending in the middle" do
     cipher = "EIEXMSMESAORIWSCE"
     assert RailFenceCipher.decode(cipher, 5) == "EXERCISMISAWESOME"
   end
 
-  @tag :skip
+  @tag :pending
   test "decode empty string" do
     assert RailFenceCipher.decode("", 4) == ""
   end
 
-  @tag :skip
+  @tag :pending
   test "decode with one rail" do
     assert RailFenceCipher.decode("ABCDEFGHIJKLMNOP", 1) == "ABCDEFGHIJKLMNOP"
   end
 
-  @tag :skip
+  @tag :pending
   test "decode letters of less than rails" do
     assert RailFenceCipher.decode("More rails than letters", 24) == "More rails than letters"
   end
 
-  @tag :skip
+  @tag :pending
   test "decode a more diverse text" do
     msg = "The quick brown fox jumps over the lazy dog."
     cipher = RailFenceCipher.encode(msg, 4)

--- a/exercises/raindrops/raindrops_test.exs
+++ b/exercises/raindrops/raindrops_test.exs
@@ -3,87 +3,87 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule RaindropsTest do
   use ExUnit.Case
 
-  # @tag :skip
+  # @tag :pending
   test "1" do
     assert Raindrops.convert(1) == "1"
   end
 
-  @tag :skip
+  @tag :pending
   test "3" do
     assert Raindrops.convert(3) == "Pling"
   end
 
-  @tag :skip
+  @tag :pending
   test "5" do
     assert Raindrops.convert(5) == "Plang"
   end
 
-  @tag :skip
+  @tag :pending
   test "7" do
     assert Raindrops.convert(7) == "Plong"
   end
 
-  @tag :skip
+  @tag :pending
   test "6" do
     assert Raindrops.convert(6) == "Pling"
   end
 
-  @tag :skip
+  @tag :pending
   test "9" do
     assert Raindrops.convert(9) == "Pling"
   end
 
-  @tag :skip
+  @tag :pending
   test "10" do
     assert Raindrops.convert(10) == "Plang"
   end
 
-  @tag :skip
+  @tag :pending
   test "14" do
     assert Raindrops.convert(14) == "Plong"
   end
 
-  @tag :skip
+  @tag :pending
   test "15" do
     assert Raindrops.convert(15) == "PlingPlang"
   end
 
-  @tag :skip
+  @tag :pending
   test "21" do
     assert Raindrops.convert(21) == "PlingPlong"
   end
 
-  @tag :skip
+  @tag :pending
   test "25" do
     assert Raindrops.convert(25) == "Plang"
   end
 
-  @tag :skip
+  @tag :pending
   test "35" do
     assert Raindrops.convert(35) == "PlangPlong"
   end
 
-  @tag :skip
+  @tag :pending
   test "49" do
     assert Raindrops.convert(49) == "Plong"
   end
 
-  @tag :skip
+  @tag :pending
   test "52" do
     assert Raindrops.convert(52) == "52"
   end
 
-  @tag :skip
+  @tag :pending
   test "105" do
     assert Raindrops.convert(105) == "PlingPlangPlong"
   end
 
-  @tag :skip
+  @tag :pending
   test "12121" do
     assert Raindrops.convert(12121) == "12121"
   end

--- a/exercises/rna-transcription/rna_transcription_test.exs
+++ b/exercises/rna-transcription/rna_transcription_test.exs
@@ -3,32 +3,32 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule RNATranscriptionTest do
   use ExUnit.Case
 
-  # @tag :skip
+  # @tag :pending
   test "transcribes guanine to cytosine" do
     assert RNATranscription.to_rna('G') == 'C'
   end
 
-  @tag :skip
+  @tag :pending
   test "transcribes cytosine to guanine" do
     assert RNATranscription.to_rna('C') == 'G'
   end
 
-  @tag :skip
+  @tag :pending
   test "transcribes thymidine to adenine" do
     assert RNATranscription.to_rna('T') == 'A'
   end
 
-  @tag :skip
+  @tag :pending
   test "transcribes adenine to uracil" do
     assert RNATranscription.to_rna('A') == 'U'
   end
 
-  @tag :skip
+  @tag :pending
   test "it transcribes all dna nucleotides to rna equivalents" do
     assert RNATranscription.to_rna('ACGTGGTCTTAA') == 'UGCACCAGAAUU'
   end

--- a/exercises/robot-simulator/robot_simulator_test.exs
+++ b/exercises/robot-simulator/robot_simulator_test.exs
@@ -3,7 +3,7 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule RobotSimulatorTest do
   use ExUnit.Case
@@ -14,7 +14,7 @@ defmodule RobotSimulatorTest do
     assert RobotSimulator.direction(robot) == :north
   end
 
-  @tag :skip
+  @tag :pending
   test "create works with valid arguments" do
     robot = RobotSimulator.create(:north, { 0, 0 })
     assert RobotSimulator.position(robot) == { 0, 0 }
@@ -33,7 +33,7 @@ defmodule RobotSimulatorTest do
     assert RobotSimulator.direction(robot) == :west
   end
 
-  @tag :skip
+  @tag :pending
   test "create errors if invalid direction given" do
     position = {0, 0}
     invalid_direction = { :error, "invalid direction" }
@@ -43,7 +43,7 @@ defmodule RobotSimulatorTest do
     assert RobotSimulator.create("east", position) == invalid_direction
   end
 
-  @tag :skip
+  @tag :pending
   test "create errors if invalid position given" do
     direction = :north
     invalid_position = { :error, "invalid position" }
@@ -58,7 +58,7 @@ defmodule RobotSimulatorTest do
     assert RobotSimulator.create(direction, nil) == invalid_position
   end
 
-  @tag :skip
+  @tag :pending
   test "simulate robots" do
     robot1 = RobotSimulator.create(:north, { 0, 0 }) |> RobotSimulator.simulate("LAAARALA")
     assert RobotSimulator.direction(robot1) == :west
@@ -73,7 +73,7 @@ defmodule RobotSimulatorTest do
     assert RobotSimulator.position(robot3) == { 11, 5 }
   end
 
-  @tag :skip
+  @tag :pending
   test "simulate errors on invalid instructions" do
     assert RobotSimulator.create |> RobotSimulator.simulate("UUDDLRLRBASTART") == { :error, "invalid instruction" }
   end

--- a/exercises/roman-numerals/roman_numerals_test.exs
+++ b/exercises/roman-numerals/roman_numerals_test.exs
@@ -3,97 +3,97 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule RomanTest do
   use ExUnit.Case
 
-  # @tag :skip
+  # @tag :pending
   test "1" do
     assert Roman.numerals(1) == "I"
   end
 
-  @tag :skip
+  @tag :pending
   test "2" do
     assert Roman.numerals(2) == "II"
   end
 
-  @tag :skip
+  @tag :pending
   test "3" do
     assert Roman.numerals(3) == "III"
   end
 
-  @tag :skip
+  @tag :pending
   test "4" do
     assert Roman.numerals(4) == "IV"
   end
 
-  @tag :skip
+  @tag :pending
   test "5" do
     assert Roman.numerals(5) == "V"
   end
 
-  @tag :skip
+  @tag :pending
   test "6" do
     assert Roman.numerals(6) == "VI"
   end
 
-  @tag :skip
+  @tag :pending
   test "9" do
     assert Roman.numerals(9) == "IX"
   end
 
-  @tag :skip
+  @tag :pending
   test "27" do
     assert Roman.numerals(27) == "XXVII"
   end
 
-  @tag :skip
+  @tag :pending
   test "48" do
     assert Roman.numerals(48) == "XLVIII"
   end
 
-  @tag :skip
+  @tag :pending
   test "59" do
     assert Roman.numerals(59) == "LIX"
   end
 
-  @tag :skip
+  @tag :pending
   test "93" do
     assert Roman.numerals(93) == "XCIII"
   end
 
-  @tag :skip
+  @tag :pending
   test "141" do
     assert Roman.numerals(141) == "CXLI"
   end
 
-  @tag :skip
+  @tag :pending
   test "163" do
     assert Roman.numerals(163) == "CLXIII"
   end
 
-  @tag :skip
+  @tag :pending
   test "402" do
     assert Roman.numerals(402) == "CDII"
   end
 
-  @tag :skip
+  @tag :pending
   test "575" do
     assert Roman.numerals(575) == "DLXXV"
   end
 
-  @tag :skip
+  @tag :pending
   test "911" do
     assert Roman.numerals(911) == "CMXI"
   end
 
-  @tag :skip
+  @tag :pending
   test "1024" do
     assert Roman.numerals(1024) == "MXXIV"
   end
 
-  @tag :skip
+  @tag :pending
   test "3000" do
     assert Roman.numerals(3000) == "MMM"
   end

--- a/exercises/run-length-encoding/rle_test.exs
+++ b/exercises/run-length-encoding/rle_test.exs
@@ -3,7 +3,7 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule RunLengthEncoderTest do
   use ExUnit.Case
@@ -12,27 +12,27 @@ defmodule RunLengthEncoderTest do
     assert RunLengthEncoder.encode("") === ""
   end
 
-  @tag :skip
+  @tag :pending
   test "simple string gets encoded" do
     assert RunLengthEncoder.encode("AAA") === "3A"
   end
 
-  @tag :skip
+  @tag :pending
   test "more complicated string" do
     assert RunLengthEncoder.encode("HORSE") == "1H1O1R1S1E"
   end
 
-  @tag :skip
+  @tag :pending
   test "an even more complex string" do
     assert RunLengthEncoder.encode("WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB") === "12W1B12W3B24W1B"
   end
 
-  @tag :skip
+  @tag :pending
   test "it decodes an encoded simple string" do
     assert RunLengthEncoder.decode("3A") === "AAA"
   end
 
-  @tag :skip
+  @tag :pending
   test "it decodes a more complicated string" do
     assert RunLengthEncoder.decode("12W1B12W3B24W1B") === "WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB"
   end

--- a/exercises/saddle-points/saddle_points_test.exs
+++ b/exercises/saddle-points/saddle_points_test.exs
@@ -3,66 +3,66 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule SaddlePointsTest do
   use ExUnit.Case
 
-  # @tag :skip
+  # @tag :pending
   test "extract rows" do
     rows = Matrix.rows("1 2\n10 20")
     assert rows == [[1, 2], [10, 20]]
   end
 
-  @tag :skip
+  @tag :pending
   test "extract a row" do
     rows = Matrix.rows("9 7\n8 6")
     assert Enum.at(rows, 0) == [9, 7]
   end
 
-  @tag :skip
+  @tag :pending
   test "extract other row" do
     rows = Matrix.rows("9 8 7\n19 18 17")
     assert Enum.at(rows, 1) == [19, 18, 17]
   end
 
-  @tag :skip
+  @tag :pending
   test "extract other row again" do
     rows = Matrix.rows("1 4 9\n16 25 36")
     assert Enum.at(rows, 1) == [16, 25, 36]
   end
 
-  @tag :skip
+  @tag :pending
   test "extract a column" do
     columns = Matrix.columns("1 2 3\n4 5 6\n7 8 9\n8 7 6")
     assert Enum.at(columns, 0) == [1, 4, 7, 8]
   end
 
-  @tag :skip
+  @tag :pending
   test "extract another column" do
     columns = Matrix.columns("89 1903 3\n18 3 1\n9 4 800")
     assert Enum.at(columns, 1) == [1903, 3, 4]
   end
 
-  @tag :skip
+  @tag :pending
   test "no saddle point" do
     saddle_points = Matrix.saddle_points("2 1\n1 2")
     assert saddle_points == []
   end
 
-  @tag :skip
+  @tag :pending
   test "a saddle point" do
     saddle_points = Matrix.saddle_points("1 2\n3 4")
     assert saddle_points == [{0, 1}]
   end
 
-  @tag :skip
+  @tag :pending
   test "another saddle point" do
     saddle_points = Matrix.saddle_points("18 3 39 19 91\n38 10 8 77 320\n3 4 8 6 7")
     assert saddle_points == [{2, 2}]
   end
 
-  @tag :skip
+  @tag :pending
   test "multiple saddle points" do
     saddle_points = Matrix.saddle_points("4 5 4\n3 5 5\n1 5 4")
     assert saddle_points == [{0, 1}, {1, 1}, {2, 1}]

--- a/exercises/scrabble-score/scrabble_score_test.exs
+++ b/exercises/scrabble-score/scrabble_score_test.exs
@@ -3,47 +3,47 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule ScrabbleScoreTest do
   use ExUnit.Case
 
-  # @tag :skip
+  # @tag :pending
   test "empty word scores zero" do
     assert Scrabble.score("") == 0
   end
 
-  @tag :skip
+  @tag :pending
   test "whitespace scores zero" do
     assert Scrabble.score(" \t\n") == 0
   end
 
-  @tag :skip
+  @tag :pending
   test "scores very short word" do
     assert Scrabble.score("a") == 1
   end
 
-  @tag :skip
+  @tag :pending
   test "scores other very short word" do
     assert Scrabble.score("f") == 4
   end
 
-  @tag :skip
+  @tag :pending
   test "simple word scores the number of letters" do
     assert Scrabble.score("street") == 6
   end
 
-  @tag :skip
+  @tag :pending
   test "complicated word scores more" do
     assert Scrabble.score("quirky") == 22
   end
 
-  @tag :skip
+  @tag :pending
   test "scores are case insensitive" do
     assert Scrabble.score("OXYPHENBUTAZONE") == 41
   end
 
-  @tag :skip
+  @tag :pending
   test "convenient scoring" do
     assert Scrabble.score("alacrity") == 13
   end

--- a/exercises/sieve/sieve_test.exs
+++ b/exercises/sieve/sieve_test.exs
@@ -3,17 +3,17 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule SieveTest do
   use ExUnit.Case
 
-  # @tag :skip
+  # @tag :pending
   test "a few primes" do
     assert Sieve.primes_to(10) == [2, 3, 5, 7]
   end
 
-  @tag :skip
+  @tag :pending
   test "primes to 1000" do
     result = [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37,
     41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83,

--- a/exercises/space-age/space_age_test.exs
+++ b/exercises/space-age/space_age_test.exs
@@ -3,7 +3,7 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 # You need to define a SpaceAge module containing a function age_on that given a
 # planet (:earth, :saturn, etc) and a number of seconds returns the age in years
@@ -12,55 +12,55 @@ ExUnit.configure trace: true
 defmodule SpageAgeTest do
   use ExUnit.Case
 
-  # @tag :skip
+  # @tag :pending
   test "age on Earth" do
     input = 1_000_000_000
     assert_in_delta 31.69, SpaceAge.age_on(:earth, input), 0.005
   end
 
-  @tag :skip
+  @tag :pending
   test "age on Mercury" do
     input = 2_134_835_688
     assert_in_delta 67.65, SpaceAge.age_on(:earth, input), 0.005
     assert_in_delta 280.88, SpaceAge.age_on(:mercury, input), 0.005
   end
 
-  @tag :skip
+  @tag :pending
   test "age on Venus" do
     input = 189_839_836
     assert_in_delta 6.02, SpaceAge.age_on(:earth, input), 0.005
     assert_in_delta 9.78, SpaceAge.age_on(:venus, input), 0.005
   end
 
-  @tag :skip
+  @tag :pending
   test "age on Mars" do
     input = 2_329_871_239
     assert_in_delta 73.83, SpaceAge.age_on(:earth, input), 0.005
     assert_in_delta 39.25, SpaceAge.age_on(:mars, input), 0.005
   end
 
-  @tag :skip
+  @tag :pending
   test "age on Jupiter" do
     input = 901_876_382
     assert_in_delta 28.58, SpaceAge.age_on(:earth, input), 0.005
     assert_in_delta 2.41, SpaceAge.age_on(:jupiter, input), 0.005
   end
 
-  @tag :skip
+  @tag :pending
   test "age on Saturn" do
     input = 3_000_000_000
     assert_in_delta 95.06, SpaceAge.age_on(:earth, input), 0.005
     assert_in_delta 3.23, SpaceAge.age_on(:saturn, input), 0.005
   end
 
-  @tag :skip
+  @tag :pending
   test "age on Uranus" do
     input = 3_210_123_456
     assert_in_delta 101.72, SpaceAge.age_on(:earth, input), 0.005
     assert_in_delta 1.21, SpaceAge.age_on(:uranus, input), 0.005
   end
 
-  @tag :skip
+  @tag :pending
   test "age on Neptune" do
     input = 8_210_123_456
     assert_in_delta 260.16, SpaceAge.age_on(:earth, input), 0.005

--- a/exercises/sublist/sublist_test.exs
+++ b/exercises/sublist/sublist_test.exs
@@ -3,7 +3,7 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule SublistTest do
   use ExUnit.Case
@@ -12,100 +12,100 @@ defmodule SublistTest do
     assert Sublist.compare([], []) == :equal
   end
 
-  @tag :skip
+  @tag :pending
   test "empty is a sublist of anything" do
     assert Sublist.compare([], [nil]) == :sublist
   end
 
-  @tag :skip
+  @tag :pending
   test "anything is a superlist of empty" do
     assert Sublist.compare([nil], []) == :superlist
   end
 
-  @tag :skip
+  @tag :pending
   test "1 is not 2" do
     assert Sublist.compare([1], [2]) == :unequal
   end
 
-  @tag :skip
+  @tag :pending
   test "comparing massive equal lists" do
     l = Enum.to_list(1..1_000_000)
     assert Sublist.compare(l, l) == :equal
   end
 
-  @tag :skip
+  @tag :pending
   test "sublist at start" do
     assert Sublist.compare([1,2,3],[1,2,3,4,5]) == :sublist
   end
 
-  @tag :skip
+  @tag :pending
   test "sublist in middle" do
     assert Sublist.compare([4,3,2],[5,4,3,2,1]) == :sublist
   end
 
-  @tag :skip
+  @tag :pending
   test "sublist at end" do
     assert Sublist.compare([3,4,5],[1,2,3,4,5]) == :sublist
   end
 
-  @tag :skip
+  @tag :pending
   test "partially matching sublist at start" do
     assert Sublist.compare([1,1,2], [1,1,1,2]) == :sublist
   end
 
-  @tag :skip
+  @tag :pending
   test "sublist early in huge list" do
     assert Sublist.compare([3,4,5], Enum.to_list(1..1_000_000)) == :sublist
   end
 
-  @tag :skip
+  @tag :pending
   test "huge sublist not in huge list" do
     assert Sublist.compare(Enum.to_list(10..1_000_001),
                            Enum.to_list(1..1_000_000))
            == :unequal
   end
 
-  @tag :skip
+  @tag :pending
   test "superlist at start" do
     assert Sublist.compare([1,2,3,4,5],[1,2,3]) == :superlist
   end
 
-  @tag :skip
+  @tag :pending
   test "superlist in middle" do
     assert Sublist.compare([5,4,3,2,1],[4,3,2]) == :superlist
   end
 
-  @tag :skip
+  @tag :pending
   test "superlist at end" do
     assert Sublist.compare([1,2,3,4,5],[3,4,5]) == :superlist
   end
 
-  @tag :skip
+  @tag :pending
   test "1 and 2 does not contain 3" do
     assert Sublist.compare([1,2], [3]) == :unequal
   end
 
-  @tag :skip
+  @tag :pending
   test "partially matching superlist at start" do
     assert Sublist.compare([1,1,1,2], [1,1,2]) == :superlist
   end
 
-  @tag :skip
+  @tag :pending
   test "superlist early in huge list" do
     assert Sublist.compare(Enum.to_list(1..1_000_000), [3,4,5]) == :superlist
   end
 
-  @tag :skip
+  @tag :pending
   test "strict equality needed" do
     assert Sublist.compare([1], [1.0, 2]) == :unequal
   end
 
-  @tag :skip
+  @tag :pending
   test "recurring values sublist" do
     assert Sublist.compare([1,2,1,2,3], [1,2,3,1,2,1,2,3,2,1]) == :sublist
   end
 
-  @tag :skip
+  @tag :pending
   test "recurring values unequal" do
     assert Sublist.compare([1,2,1,2,3], [1,2,3,1,2,3,2,3,2,1]) == :unequal
   end

--- a/exercises/sum-of-multiples/sum_of_multiples_test.exs
+++ b/exercises/sum-of-multiples/sum_of_multiples_test.exs
@@ -3,60 +3,60 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule SumOfMultiplesTest do
   use ExUnit.Case
 
-  # @tag :skip
+  # @tag :pending
   test "sum to 1" do
     assert SumOfMultiples.to(1, [3, 5]) == 0
   end
 
-  @tag :skip
+  @tag :pending
   test "sum to 3" do
     assert SumOfMultiples.to(4, [3, 5]) == 3
   end
 
-  @tag :skip
+  @tag :pending
   test "sum to 10" do
     assert SumOfMultiples.to(10, [3, 5]) == 23
   end
 
-  @tag :skip
+  @tag :pending
   test "sum to 20" do
     assert SumOfMultiples.to(20, [3, 5]) == 78
   end
 
-  @tag :skip
+  @tag :pending
   test "sum to 100" do
     assert SumOfMultiples.to(100, [3, 5]) == 2318
   end
 
-  @tag :skip
+  @tag :pending
   test "sum to 1000" do
     assert SumOfMultiples.to(1000, [3, 5]) == 233168
   end
 
-  @tag :skip
+  @tag :pending
   test "configurable 7, 13, 17 to 20" do
     multiples = [7, 13, 17]
     assert SumOfMultiples.to(20, multiples) == 51
   end
 
-  @tag :skip
+  @tag :pending
   test "configurable 4, 6 to 15" do
     multiples = [4, 6]
     assert SumOfMultiples.to(15, multiples) == 30
   end
 
-  @tag :skip
+  @tag :pending
   test "configurable 5, 6, 8 to 150" do
     multiples = [5, 6, 8]
     assert SumOfMultiples.to(150, multiples) == 4419
   end
 
-  @tag :skip
+  @tag :pending
   test "configurable 43, 47 to 10000" do
     multiples = [43, 47]
     assert SumOfMultiples.to(10000, multiples) == 2203160

--- a/exercises/test_helper.exs
+++ b/exercises/test_helper.exs
@@ -3,5 +3,5 @@
 |> Kernel.ParallelRequire.files
 
 System.put_env("EXERCISM_TEST_EXAMPLES", "true")
-ExUnit.configure include: :skip
+ExUnit.configure include: :pending
 ExUnit.start

--- a/exercises/triangle/triangle_test.exs
+++ b/exercises/triangle/triangle_test.exs
@@ -3,82 +3,82 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule TriangleTest do
   use ExUnit.Case
 
-  # @tag :skip
+  # @tag :pending
   test "equilateral triangles have equal sides" do
     assert Triangle.kind(2, 2, 2) == { :ok, :equilateral }
   end
 
-  @tag :skip
+  @tag :pending
   test "larger equilateral triangles also have equal sides" do
     assert Triangle.kind(10, 10, 10) == { :ok, :equilateral }
   end
 
-  @tag :skip
+  @tag :pending
   test "isosceles triangles have last two sides equal" do
     assert Triangle.kind(3, 4, 4) == { :ok, :isosceles }
   end
 
-  @tag :skip
+  @tag :pending
   test "isosceles triangles have first and last sides equal" do
     assert Triangle.kind(4, 3, 4) == { :ok, :isosceles }
   end
 
-  @tag :skip
+  @tag :pending
   test "isosceles triangles have two first sides equal" do
     assert Triangle.kind(4, 4, 3) == { :ok, :isosceles }
   end
 
-  @tag :skip
+  @tag :pending
   test "isosceles triangles have in fact exactly two sides equal" do
     assert Triangle.kind(10, 10, 2) == { :ok, :isosceles }
   end
 
-  @tag :skip
+  @tag :pending
   test "scalene triangles have no equal sides" do
     assert Triangle.kind(3, 4, 5) == { :ok, :scalene }
   end
 
-  @tag :skip
+  @tag :pending
   test "scalene triangles have no equal sides at a larger scale too" do
     assert Triangle.kind(10, 11, 12) == { :ok, :scalene }
   end
 
-  @tag :skip
+  @tag :pending
   test "scalene triangles have no equal sides in descending order either" do
     assert Triangle.kind(5, 4, 2) == { :ok, :scalene }
   end
 
-  @tag :skip
+  @tag :pending
   test "very small triangles are legal" do
     assert Triangle.kind(0.4, 0.6, 0.3) == { :ok, :scalene }
   end
 
-  @tag :skip
+  @tag :pending
   test "triangles with no size are illegal" do
     assert Triangle.kind(0, 0, 0) == { :error, "all side lengths must be positive" }
   end
 
-  @tag :skip
+  @tag :pending
   test "triangles with negative sides are illegal" do
     assert Triangle.kind(3, 4, -5) == { :error, "all side lengths must be positive" }
   end
 
-  @tag :skip
+  @tag :pending
   test "triangles violating triangle inequality are illegal" do
     assert Triangle.kind(1, 1, 3) == { :error, "side lengths violate triangle inequality" }
   end
 
-  @tag :skip
+  @tag :pending
   test "triangles violating triangle inequality are illegal 2" do
     assert Triangle.kind(2, 4, 2) == { :error, "side lengths violate triangle inequality" }
   end
 
-  @tag :skip
+  @tag :pending
   test "triangles violating triangle inequality are illegal 3" do
     assert Triangle.kind(7, 3, 2) == { :error, "side lengths violate triangle inequality" }
   end

--- a/exercises/word-count/word_count_test.exs
+++ b/exercises/word-count/word_count_test.exs
@@ -3,7 +3,7 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule WordsTest do
   use ExUnit.Case
@@ -12,49 +12,49 @@ defmodule WordsTest do
     assert Words.count("word") == %{ "word" => 1 }
   end
 
-  @tag :skip
+  @tag :pending
   test "count one of each" do
     expected = %{ "one" => 1 ,  "of" => 1 ,  "each" => 1 }
     assert Words.count("one of each") == expected
   end
 
-  @tag :skip
+  @tag :pending
   test "count multiple occurrences" do
     expected = %{ "one" => 1 ,  "fish" => 4 ,  "two" => 1 ,  "red" => 1 ,  "blue" => 1 }
     assert Words.count("one fish two fish red fish blue fish") == expected
   end
 
-  @tag :skip
+  @tag :pending
   test "ignore punctuation" do
     expected = %{"car" => 1, "carpet" => 1, "as" => 1, "java" => 1, "javascript" => 1}
     assert Words.count("car : carpet as java : javascript!!&@$%^&") == expected
   end
 
-  @tag :skip
+  @tag :pending
   test "include numbers" do
     expected = %{"testing" => 2, "1" => 1, "2" => 1}
     assert Words.count("testing, 1, 2 testing") == expected
   end
 
-  @tag :skip
+  @tag :pending
   test "hyphens" do
     expected = %{"co-operative" => 1}
     assert Words.count("co-operative") == expected
   end
 
-  @tag :skip
+  @tag :pending
   test "ignore underscores" do
     expected = %{"two" => 1, "words" => 1}
     assert Words.count("two_words") == expected
   end
 
-  @tag :skip
+  @tag :pending
   test "normalize case" do
     expected = %{"go" => 3}
     assert Words.count("go Go GO") == expected
   end
 
-  @tag :skip
+  @tag :pending
   test "German" do
     expected = %{"götterfunken" => 1, "schöner" => 1, "freude" => 1}
     assert Words.count("Freude schöner Götterfunken") == expected

--- a/exercises/wordy/wordy_test.exs
+++ b/exercises/wordy/wordy_test.exs
@@ -3,7 +3,7 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule WordyTest do
   use ExUnit.Case
@@ -12,79 +12,79 @@ defmodule WordyTest do
     assert Wordy.answer("What is 1 plus 1?") == 2
   end
 
-  @tag :skip
+  @tag :pending
   test "more addition" do
     assert Wordy.answer("What is 53 plus 2?") == 55
   end
 
-  @tag :skip
+  @tag :pending
   test "addition with negative numbers" do
     assert Wordy.answer("What is -1 plus -10?") == -11
   end
 
-  @tag :skip
+  @tag :pending
   test "large addition" do
     assert Wordy.answer("What is 123 plus 45678?") == 45801
   end
 
-  @tag :skip
+  @tag :pending
   test "subtraction" do
     assert Wordy.answer("What is 4 minus -12?") == 16
   end
 
-  @tag :skip
+  @tag :pending
   test "multiplication" do
     assert Wordy.answer("What is -3 multiplied by 25?") == -75
   end
 
-  @tag :skip
+  @tag :pending
   test "division" do
     assert Wordy.answer("What is 33 divided by -3?") == -11
   end
 
-  @tag :skip
+  @tag :pending
   test "multiple additions" do
     assert Wordy.answer("What is 1 plus 1 plus 1?") == 3
   end
 
-  @tag :skip
+  @tag :pending
   test "addition and subtraction" do
     assert Wordy.answer("What is 1 plus 5 minus -2?") == 8
   end
 
-  @tag :skip
+  @tag :pending
   test "multiple subtraction" do
     assert Wordy.answer("What is 20 minus 4 minus 13?") == 3
   end
 
-  @tag :skip
+  @tag :pending
   test "subtraction then addition" do
     assert Wordy.answer("What is 17 minus 6 plus 3?") == 14
   end
 
-  @tag :skip
+  @tag :pending
   test "multiple multiplication" do
     assert Wordy.answer("What is 2 multiplied by -2 multiplied by 3?") == -12
   end
 
-  @tag :skip
+  @tag :pending
   test "addition and multiplication" do
     assert Wordy.answer("What is -3 plus 7 multiplied by -2?") == -8
   end
 
-  @tag :skip
+  @tag :pending
   test "multiple division" do
     assert Wordy.answer("What is -12 divided by 2 divided by -3?") == 2
   end
 
-  @tag :skip
+  @tag :pending
   test "unknown operation" do
     assert_raise ArgumentError, fn ->
       Wordy.answer("What is 52 cubed?")
     end
   end
 
-  @tag :skip
+  @tag :pending
   test "Non math question" do
     assert_raise ArgumentError, fn ->
       Wordy.answer("Who is the President of the United States?")

--- a/exercises/zipper/zipper_test.exs
+++ b/exercises/zipper/zipper_test.exs
@@ -3,7 +3,7 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure trace: true
+ExUnit.configure exclude: :pending, trace: true
 
 defmodule ZipperTest do
   alias BinTree, as: BT
@@ -21,62 +21,62 @@ defmodule ZipperTest do
                      bt(6, leaf(7), leaf(8)))
   defp t6, do: bt(1, bt(2, nil,     leaf(5)), leaf(4))
 
-  # @tag :skip
+  # @tag :pending
   test "data is retained" do
     assert (t1 |> from_tree |> to_tree) == t1
   end
 
-  @tag :skip
+  @tag :pending
   test "left, right and value" do
     assert (t1 |> from_tree |> left |> right |> value) == 3
   end
 
-  @tag :skip
+  @tag :pending
   test "dead end" do
     assert (t1 |> from_tree |> left |> left) == nil
   end
 
-  @tag :skip
+  @tag :pending
   test "tree from deep focus" do
     assert (t1 |> from_tree |> left |> right |> to_tree) == t1
   end
 
-  @tag :skip
+  @tag :pending
   test "traversing up from top" do
     assert (t1 |> from_tree |> up) == nil
   end
 
-  @tag :skip
+  @tag :pending
   test "left, right, and up" do
     assert (t1 |> from_tree |> left |> up |> right |> up |> left |> right |> value) == 3
   end
 
-  @tag :skip
+  @tag :pending
   test "set_value" do
     assert (t1 |> from_tree |> left |> set_value(5) |> to_tree) == t2
   end
 
-  @tag :skip
+  @tag :pending
   test "set_value after traversing up" do
     assert (t1 |> from_tree |> left |> right |> up |> set_value(5) |> to_tree) == t2
   end
 
-  @tag :skip
+  @tag :pending
   test "set_left with leaf" do
     assert (t1 |> from_tree |> left |> set_left(leaf(5)) |> to_tree) == t3
   end
 
-  @tag :skip
+  @tag :pending
   test "set_right with nil" do
     assert (t1 |> from_tree |> left |> set_right(nil) |> to_tree) == t4
   end
 
-  @tag :skip
+  @tag :pending
   test "set_right with subtree" do
     assert (t1 |> from_tree |> set_right(bt(6, leaf(7), leaf(8))) |> to_tree) == t5
   end
 
-  @tag :skip
+  @tag :pending
   test "set_value on deep focus" do
     assert (t1 |> from_tree |> left |> right |> set_value(5) |> to_tree) == t6
   end


### PR DESCRIPTION
This reverts commit 2ae55a4723089984bf02c7e50a01e8ce97ca7e3c.

I'm sorry to say that we missed the fact that tests marked with `skip` are not being run despite configuring CI to include them. I have re-created this behavior in a plain elixir app. As far as I can tell there is no way to un-skip tests marked with `skip`. This seems to be a bug in ExUnit. I'm reverting this change until ExUnit changes or until we find a way to include these tests.

This was good lesson for me to carefully check the build whenever we make sweeping changes to how tests are run. 😞 