### PR TITLE
Update binary_search_test.exs : returns :not_found when key is too high

### DIFF
--- a/exercises/binary-search/binary_search_test.exs
+++ b/exercises/binary-search/binary_search_test.exs
@@ -16,6 +16,11 @@ defmodule BinarySearchTest do
   test "returns :not_found when key is not in the tuple" do
     assert BinarySearch.search({2, 4, 6}, 3) == :not_found
   end
+  
+  @tag :pending
+  test "returns :not_found when key is too high" do
+    assert BinarySearch.search({2, 4, 6}, 9) == :not_found
+  end
 
   @tag :pending
   test "finds key in a tuple with a single item" do

--- a/exercises/binary-search/binary_search_test.exs
+++ b/exercises/binary-search/binary_search_test.exs
@@ -16,7 +16,7 @@ defmodule BinarySearchTest do
   test "returns :not_found when key is not in the tuple" do
     assert BinarySearch.search({2, 4, 6}, 3) == :not_found
   end
-  
+
   @tag :pending
   test "returns :not_found when key is too high" do
     assert BinarySearch.search({2, 4, 6}, 9) == :not_found


### PR DESCRIPTION
Many solutions I've seen fail on this test.