### PR TITLE
Change `markdown` exercise to be a refactoring exercise

### DIFF
--- a/exercises/markdown/markdown.exs
+++ b/exercises/markdown/markdown.exs
@@ -10,9 +10,66 @@ defmodule Markdown do
     iex> Markdown.parse("#Header!\n* __Bold Item__\n* _Italic Item_")
     "<h1>Header!</h1><ul><li><em>Bold Item</em></li><li><i>Italic Item</i></li></ul>"
   """
-
   @spec parse(String.t) :: String.t
-  def parse(markdown) do
+  def parse(m) do
+    patch(Enum.join(Enum.map(String.split(m, "\n"), fn(t) -> process(t) end)))
+  end
 
+  defp process(t) do
+    if String.starts_with?(t, "#") || String.starts_with?(t, "*") do
+      if String.starts_with?(t, "#") do
+        enclose_with_header_tag(parse_header_md_level(t))
+      else
+        parse_list_md_level(t)
+      end
+    else
+      enclose_with_paragraph_tag(String.split(t))
+    end
+  end
+
+  defp parse_header_md_level(hwt) do
+    [h | t] = String.split(hwt)
+    {to_string(String.length(h)), Enum.join(t, " ")}
+  end
+
+  defp parse_list_md_level(l) do
+    t = String.split(String.trim_leading(l, "* "))
+    "<li>" <> join_words_with_tags(t) <> "</li>"
+  end
+
+  defp enclose_with_header_tag({hl, htl}) do
+    "<h" <> hl <> ">" <> htl <> "</h" <> hl <> ">"
+  end
+
+  defp enclose_with_paragraph_tag(t) do
+    "<p>#{join_words_with_tags(t)}</p>"
+  end
+
+  defp join_words_with_tags(t) do
+    Enum.join(Enum.map(t, fn(w) -> replace_md_with_tag(w) end), " ")
+  end
+
+  defp replace_md_with_tag(w) do
+    replace_suffix_md(replace_prefix_md(w))
+  end
+
+  defp replace_prefix_md(w) do
+    cond do
+      w =~ ~r/^#{"__"}{1}/ -> String.replace(w, ~r/^#{"__"}{1}/, "<strong>", global: false)
+      w =~ ~r/^[#{"_"}{1}][^#{"_"}+]/ -> String.replace(w, ~r/_/, "<em>", global: false)
+      true -> w
+    end
+  end
+
+  defp replace_suffix_md(w) do
+    cond do
+      w =~ ~r/#{"__"}{1}$/ -> String.replace(w, ~r/#{"__"}{1}$/, "</strong>")
+      w =~ ~r/[^#{"_"}{1}]/ -> String.replace(w, ~r/_/, "</em>")
+      true -> w
+    end
+  end
+
+  defp patch(l) do
+    String.replace_suffix(String.replace(l, "<li>", "<ul>" <> "<li>", global: false), "</li>", "</li>" <> "</ul>")
   end
 end


### PR DESCRIPTION
The implementation we had for `markdown` wasn't entirely in line with what was
set out in `x-common`, so I've changed it here. Basically I took the original
implemntation that we had in the `example.exs` file and made it a whole lot
worse! One of my favorite ways to make something really bad is to use single
letter variable names instead of descriptive variables, so I've done that. I
also removed a bunch of pipe operators, used inconsistent string interplation
versus string concatenation, and added in some gnarly `if` statements for fun.
The tests all still pass, though!

Let's hope we never see code like this in our "real" lives, but I have to say
it was kind of fun to do! Let me know if this is too cruel and if I should make it a
little easier to handle, cause right now it might be _too_ tough to refactor!

Closes #252