### PR TITLE
Replaced last trailing space with "\s"

### DIFF
--- a/exercises/diamond/diamond_test.exs
+++ b/exercises/diamond/diamond_test.exs
@@ -38,7 +38,7 @@ defmodule DiamondTest do
 \sD     D\s
 \s C   C \s
 \s  B B  \s
-\s   A   \s  
+\s   A   \s
     """
   end
 end

--- a/exercises/diamond/diamond_test.exs
+++ b/exercises/diamond/diamond_test.exs
@@ -18,11 +18,11 @@ defmodule DiamondTest do
   test "letter C" do
     shape = Diamond.build_shape(?C)
     assert shape == """
-\s A  
-\sB B 
+\s A \s
+\sB B\s
  C   C
-\sB B 
-\s A  
+\sB B\s
+\s A \s
     """
   end
 
@@ -30,15 +30,15 @@ defmodule DiamondTest do
   test "letter E" do
     shape = Diamond.build_shape(?E)
     assert shape == """
-\s   A    
-\s  B B   
-\s C   C  
-\sD     D 
+\s   A   \s
+\s  B B  \s
+\s C   C \s
+\sD     D\s
  E       E
-\sD     D 
-\s C   C  
-\s  B B   
-\s   A    
+\sD     D\s
+\s C   C \s
+\s  B B  \s
+\s   A   \s  
     """
   end
 end


### PR DESCRIPTION
Some editors automatically trim whitespace so I replaced the last trailing space with "\s".