### PR TITLE
Reference latest book version: Programming Elixir 1.3

### DIFF
--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -2,7 +2,7 @@ Exercism provides exercises and feedback but can be difficult to jump into for t
 
 * [Elixir Getting Started Guide](http://elixir-lang.org/getting-started/introduction.html)
 * [Elixir Documentation](http://elixir-lang.org/docs/stable/elixir/)
-* [Programming Elixir](http://pragprog.com/book/elixir/programming-elixir), by Dave Thomas
+* [Programming Elixir](https://pragprog.com/book/elixir13/programming-elixir-1-3), by Dave Thomas
 * [StackOverflow](http://stackoverflow.com/questions/tagged/elixir)
 * [Introducing Elixir](http://shop.oreilly.com/product/0636920030584.do), by Simon St. Laurent, J. David Eisenberg
 * [Etudes for Elixir](http://chimera.labs.oreilly.com/books/1234000001642), by J. David Eisenberg (exercise companion for Intro to Elixir)


### PR DESCRIPTION
The older versions of Programming Elixir are out of print. 

To save a couple of clicks and a few seconds of figuring out what's going on, reference the latest version directly.

/review @kytrinyx, @parkerl, @devonestes