### PR TITLE
Add parentheses to zero arity functions

### DIFF
--- a/exercises/zipper/zipper_test.exs
+++ b/exercises/zipper/zipper_test.exs
@@ -23,61 +23,61 @@ defmodule ZipperTest do
 
   # @tag :pending
   test "data is retained" do
-    assert (t1 |> from_tree |> to_tree) == t1
+    assert (t1() |> from_tree |> to_tree) == t1()
   end
 
   @tag :pending
   test "left, right and value" do
-    assert (t1 |> from_tree |> left |> right |> value) == 3
+    assert (t1() |> from_tree |> left |> right |> value) == 3
   end
 
   @tag :pending
   test "dead end" do
-    assert (t1 |> from_tree |> left |> left) == nil
+    assert (t1() |> from_tree |> left |> left) == nil
   end
 
   @tag :pending
   test "tree from deep focus" do
-    assert (t1 |> from_tree |> left |> right |> to_tree) == t1
+    assert (t1() |> from_tree |> left |> right |> to_tree) == t1()
   end
 
   @tag :pending
   test "traversing up from top" do
-    assert (t1 |> from_tree |> up) == nil
+    assert (t1() |> from_tree |> up) == nil
   end
 
   @tag :pending
   test "left, right, and up" do
-    assert (t1 |> from_tree |> left |> up |> right |> up |> left |> right |> value) == 3
+    assert (t1() |> from_tree |> left |> up |> right |> up |> left |> right |> value) == 3
   end
 
   @tag :pending
   test "set_value" do
-    assert (t1 |> from_tree |> left |> set_value(5) |> to_tree) == t2
+    assert (t1() |> from_tree |> left |> set_value(5) |> to_tree) == t2()
   end
 
   @tag :pending
   test "set_value after traversing up" do
-    assert (t1 |> from_tree |> left |> right |> up |> set_value(5) |> to_tree) == t2
+    assert (t1() |> from_tree |> left |> right |> up |> set_value(5) |> to_tree) == t2()
   end
 
   @tag :pending
   test "set_left with leaf" do
-    assert (t1 |> from_tree |> left |> set_left(leaf(5)) |> to_tree) == t3
+    assert (t1() |> from_tree |> left |> set_left(leaf(5)) |> to_tree) == t3()
   end
 
   @tag :pending
   test "set_right with nil" do
-    assert (t1 |> from_tree |> left |> set_right(nil) |> to_tree) == t4
+    assert (t1() |> from_tree |> left |> set_right(nil) |> to_tree) == t4()
   end
 
   @tag :pending
   test "set_right with subtree" do
-    assert (t1 |> from_tree |> set_right(bt(6, leaf(7), leaf(8))) |> to_tree) == t5
+    assert (t1() |> from_tree |> set_right(bt(6, leaf(7), leaf(8))) |> to_tree) == t5()
   end
 
   @tag :pending
   test "set_value on deep focus" do
-    assert (t1 |> from_tree |> left |> right |> set_value(5) |> to_tree) == t6
+    assert (t1() |> from_tree |> left |> right |> set_value(5) |> to_tree) == t6()
   end
 end


### PR DESCRIPTION
Resolves the ambiguity warnings in Elixir 1.4