### PR TITLE
Fix all deprecation warnings from running `mix test` with Elixir 1.4.0

### DIFF
--- a/exercises/allergies/allergies_test.exs
+++ b/exercises/allergies/allergies_test.exs
@@ -75,9 +75,9 @@ defmodule AllergiesTest do
     set = Enum.into(list, MapSet.new)
     same_contents = to_contain
       |> Enum.into(MapSet.new)
-      |> Set.equal?(set)
+      |> MapSet.equal?(set)
     assert same_contents,
-           "Expected a set with: #{inspect to_contain} got #{inspect set |> Set.to_list}"
+           "Expected a set with: #{inspect to_contain} got #{inspect set |> MapSet.to_list}"
   end
 
 end

--- a/exercises/markdown/example.exs
+++ b/exercises/markdown/example.exs
@@ -27,9 +27,9 @@ defmodule Markdown do
 
   defp process_md(text_with_md) do
     cond do
-      String.starts_with?(text_with_md, "#") -> parse_header_md_level(text_with_md) |> enclose_with_header_tag
-      String.starts_with?(text_with_md, "*") -> parse_list_md_level(text_with_md)
-      true                                   -> String.split(text_with_md) |> enclose_with_paragraph_tag
+      String.starts_with?(text_with_md, @header_md) -> parse_header_md_level(text_with_md) |> enclose_with_header_tag
+      String.starts_with?(text_with_md, @list_md)   -> parse_list_md_level(text_with_md)
+      true                                          -> String.split(text_with_md) |> enclose_with_paragraph_tag
     end
   end
 

--- a/exercises/phone-number/example.exs
+++ b/exercises/phone-number/example.exs
@@ -3,8 +3,6 @@ defmodule Phone do
   Utilities to work with phone numbers.
   """
 
-  @bad_result "0000000000"
-
   @doc """
   Clean up a phone number.
 

--- a/exercises/queen-attack/example.exs
+++ b/exercises/queen-attack/example.exs
@@ -19,7 +19,7 @@ defmodule Queens do
   """
   @spec to_string(Queens.t()) :: String.t()
   def to_string(%Queens{ white: white, black: black }) do
-    generate_board
+    generate_board()
     |> insert_queen(white, "W")
     |> insert_queen(black, "B")
     |> Enum.map(&Enum.join(&1, " "))

--- a/exercises/wordy/example.exs
+++ b/exercises/wordy/example.exs
@@ -16,7 +16,7 @@ defmodule Wordy do
   end
 
   defp tokenize(sentence) do
-    Regex.scan(~r/(#{all_matchers})/, sentence)
+    Regex.scan(~r/(#{all_matchers()})/, sentence)
     |> Enum.map(&(Enum.at(&1,0)))
   end
 
@@ -53,7 +53,7 @@ defmodule Wordy do
     end
 
     def match?(token) do
-      String.match?(token,~r/#{matcher}/)
+      String.match?(token,~r/#{matcher()}/)
     end
 
     def parse(token) do
@@ -67,7 +67,7 @@ defmodule Wordy do
     end
 
     def match?(token) do
-      String.match?(token,~r/#{matcher}/)
+      String.match?(token,~r/#{matcher()}/)
     end
 
     def parse(_) do
@@ -85,7 +85,7 @@ defmodule Wordy do
     end
 
     def match?(token) do
-      String.match?(token,~r/#{matcher}/)
+      String.match?(token,~r/#{matcher()}/)
     end
 
     def parse(_) do
@@ -103,7 +103,7 @@ defmodule Wordy do
     end
 
     def match?(token) do
-      String.match?(token,~r/#{matcher}/)
+      String.match?(token,~r/#{matcher()}/)
     end
 
     def parse(_) do
@@ -121,7 +121,7 @@ defmodule Wordy do
     end
 
     def match?(token) do
-      String.match?(token,~r/#{matcher}/)
+      String.match?(token,~r/#{matcher()}/)
     end
 
     def parse(_) do

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule ExercismTestRunner.Mixfile do
     [app: :tests,
      version: "0.0.1",
      elixir: "~> 1.3",
-     deps: deps,
+     deps: deps(),
      test_paths: ["exercises"],
      consolidate_protocols: false]
   end


### PR DESCRIPTION
I looked at #286 and noticed there are other deprecation warnings from Elixir 1.4. Most are on zero-arity functions, some on unused module attributes, and a few remaining deprecations to use `MapSet` instead of `Set`.