### PR TITLE
Add tests for exception cases to match canonical-data.json

### DIFF
--- a/exercises/grains/example.exs
+++ b/exercises/grains/example.exs
@@ -1,6 +1,6 @@
 defmodule Grains do
   use Bitwise, only_operators: true
-  def square(number) when number in (1..64), do: 1 <<< (number - 1)
-  def square(_), do: raise ArgumentError, message: "The requested square must be between 1 and 64 (inclusive )"
-  def total, do: Enum.reduce(1..64, 0, fn(n, acc) -> acc + square(n) end)
+  def square(number) when number in (1..64), do: { :ok, 1 <<< (number - 1) }
+  def square(_), do: { :error, "The requested square must be between 1 and 64 (inclusive)" }
+  def total, do: { :ok, Enum.reduce(1..64, 0, fn(n, acc) -> {:ok, sq} = square(n); acc + sq end) }
 end

--- a/exercises/grains/example.exs
+++ b/exercises/grains/example.exs
@@ -1,5 +1,6 @@
 defmodule Grains do
   use Bitwise, only_operators: true
-  def square(number), do: 1 <<< (number - 1)
+  def square(number) when number in (1..64), do: 1 <<< (number - 1)
+  def square(_), do: raise ArgumentError, message: "The requested square must be between 1 and 64 (inclusive )"
   def total, do: Enum.reduce(1..64, 0, fn(n, acc) -> acc + square(n) end)
 end

--- a/exercises/grains/grains_test.exs
+++ b/exercises/grains/grains_test.exs
@@ -16,57 +16,57 @@ defmodule GrainsTest do
 
   # @tag :pending
   test "square 1" do
-    assert Grains.square(1) === 1
+    assert Grains.square(1) === { :ok, 1 }
   end
 
   @tag :pending
   test "square 2" do
-    assert Grains.square(2) === 2
+    assert Grains.square(2) === { :ok, 2 }
   end
 
   @tag :pending
   test "square 3" do
-    assert Grains.square(3) === 4
+    assert Grains.square(3) === { :ok, 4 }
   end
 
   @tag :pending
   test "square 4" do
-    assert Grains.square(4) === 8
+    assert Grains.square(4) === { :ok, 8 }
   end
 
   @tag :pending
   test "square 16" do
-    assert Grains.square(16) === 32768
+    assert Grains.square(16) === { :ok, 32768 }
   end
 
   @tag :pending
   test "square 32" do
-    assert Grains.square(32) === 2147483648
+    assert Grains.square(32) === { :ok, 2147483648 }
   end
 
   @tag :pending
   test "square 64" do
-    assert Grains.square(64) === 9223372036854775808
+    assert Grains.square(64) === { :ok, 9223372036854775808 }
   end
 
   @tag :pending
   test "total grains" do
-    assert Grains.total === 18446744073709551615
+    assert Grains.total === { :ok, 18446744073709551615 }
   end
 
   @tag :pending
   test "square greater than 64 raises an exception" do
-    catch_error Grains.square(65)
+    assert Grains.square(65) === { :error, "The requested square must be between 1 and 64 (inclusive)" }
   end
 
   @tag :pending
   test "negative square raises an exception" do
-    catch_error Grains.square(-1)
+    assert Grains.square(-1) === { :error, "The requested square must be between 1 and 64 (inclusive)" }
   end
 
   @tag :pending
   test "square 0 raises an exception" do
-    catch_error Grains.square(0)
+    assert Grains.square(0) === { :error, "The requested square must be between 1 and 64 (inclusive)" }
   end
 
 end

--- a/exercises/grains/grains_test.exs
+++ b/exercises/grains/grains_test.exs
@@ -55,17 +55,17 @@ defmodule GrainsTest do
   end
 
   @tag :pending
-  test "square greater than 64 raises an exception" do
+  test "square greater than 64 returns an error" do
     assert Grains.square(65) === { :error, "The requested square must be between 1 and 64 (inclusive)" }
   end
 
   @tag :pending
-  test "negative square raises an exception" do
+  test "negative square returns an error" do
     assert Grains.square(-1) === { :error, "The requested square must be between 1 and 64 (inclusive)" }
   end
 
   @tag :pending
-  test "square 0 raises an exception" do
+  test "square 0 returns an error" do
     assert Grains.square(0) === { :error, "The requested square must be between 1 and 64 (inclusive)" }
   end
 

--- a/exercises/grains/grains_test.exs
+++ b/exercises/grains/grains_test.exs
@@ -53,4 +53,20 @@ defmodule GrainsTest do
   test "total grains" do
     assert Grains.total === 18446744073709551615
   end
+
+  @tag :pending
+  test "square greater than 64 raises an exception" do
+    catch_error Grains.square(65)
+  end
+
+  @tag :pending
+  test "negative square raises an exception" do
+    catch_error Grains.square(-1)
+  end
+
+  @tag :pending
+  test "square 0 raises an exception" do
+    catch_error Grains.square(0)
+  end
+
 end


### PR DESCRIPTION
To bring the existing test suite up to speed with the [shared canonical data version](https://github.com/exercism/x-common/blob/master/exercises/grains/canonical-data.json) I added 3 exception tests for squares -1, 0 and 65.
