### PR TITLE
Add exercise 'series'

### DIFF
--- a/config.json
+++ b/config.json
@@ -60,6 +60,13 @@
       ]
     },
     {
+      "slug": "series",
+      "difficulty": 2,
+      "topics": [
+        "string processing"
+      ]
+    },
+    {
       "slug": "raindrops",
       "difficulty": 2,
       "topics": [

--- a/exercises/series/example.exs
+++ b/exercises/series/example.exs
@@ -4,7 +4,7 @@ defmodule StringSeries do
   of that size. If `size` is greater than the length of `s`, or less than 1,
   return an empty list.
   """
-  @spec slices(s :: String.t(), size :: integer) :: any
+  @spec slices(s :: String.t(), size :: integer) :: list(String.t())
   def slices(_s, size) when size < 1, do: []
   def slices(s, size) do
     s |> String.graphemes |> Enum.chunk(size, 1) |> Enum.map(&Enum.join/1)

--- a/exercises/series/example.exs
+++ b/exercises/series/example.exs
@@ -1,0 +1,13 @@
+defmodule StringSeries do
+  @doc """
+  Given a string `s` and a positive integer `size`, return all substrings
+  of that size. If `size` is greater than the length of `s`, or less than 1,
+  return an empty list.
+  """
+  @spec slices(s :: String.t(), size :: integer) :: any
+  def slices(_s, size) when size < 1, do: []
+  def slices(s, size) do
+    s |> String.graphemes |> Enum.chunk(size, 1) |> Enum.map(&Enum.join/1)
+  end
+end
+

--- a/exercises/series/series.exs
+++ b/exercises/series/series.exs
@@ -4,7 +4,7 @@ defmodule StringSeries do
   of that size. If `size` is greater than the length of `s`, or less than 1,
   return an empty list.
   """
-  @spec slices(s :: String.t(), size :: integer) :: any
+  @spec slices(s :: String.t(), size :: integer) :: list(String.t())
   def slices(_s, _size) do
   end
 end

--- a/exercises/series/series.exs
+++ b/exercises/series/series.exs
@@ -1,0 +1,11 @@
+defmodule StringSeries do
+  @doc """
+  Given a string `s` and a positive integer `size`, return all substrings
+  of that size. If `size` is greater than the length of `s`, or less than 1,
+  return an empty list.
+  """
+  @spec slices(s :: String.t(), size :: integer) :: any
+  def slices(_s, _size) do
+  end
+end
+

--- a/exercises/series/series_test.exs
+++ b/exercises/series/series_test.exs
@@ -1,0 +1,57 @@
+if !System.get_env("EXERCISM_TEST_EXAMPLES") do
+  Code.load_file("series.exs", __DIR__)
+end
+
+ExUnit.start
+ExUnit.configure exclude: :pending, trace: true
+
+defmodule StringSeriesTest do
+  use ExUnit.Case
+
+  test "slices of 1" do
+    assert StringSeries.slices("01234", 1) == ["0", "1", "2", "3", "4"]
+    assert StringSeries.slices("92834", 1) == ["9", "2", "8", "3", "4"]
+  end
+
+  @tag :pending
+  test "slices of 2" do
+    assert StringSeries.slices("01234", 2) == ["01", "12", "23", "34"]
+    assert StringSeries.slices("98273463", 2) == ["98", "82", "27", "73", "34", "46", "63"]
+    assert StringSeries.slices("37103", 2) == ["37", "71", "10", "03"]
+  end
+
+  @tag :pending
+  test "slices of 3" do
+    assert StringSeries.slices("01234", 3) == ["012", "123", "234"]
+    assert StringSeries.slices("31001", 3) == ["310", "100", "001"]
+    assert StringSeries.slices("982347", 3) == ["982", "823", "234", "347"]
+  end
+
+  @tag :pending
+  test "slices of 4" do
+    assert StringSeries.slices("01234", 4) == ["0123", "1234"]
+    assert StringSeries.slices("91274", 4) == ["9127", "1274"]
+  end
+
+  @tag :pending
+  test "slices same size as string" do
+    assert StringSeries.slices("01234", 5) == ["01234"]
+    assert StringSeries.slices("31001", 5) == ["31001"]
+    assert StringSeries.slices("982347", 6) == ["982347"]
+  end
+
+  @tag :pending
+  test "slices bigger than string" do
+    assert StringSeries.slices("01234", 6) == []
+    assert StringSeries.slices("31001", 6) == []
+    assert StringSeries.slices("982347", 7) == []
+  end
+
+  @tag :pending
+  test "negative-sized slices" do
+    assert StringSeries.slices("01234", -2) == []
+    assert StringSeries.slices("31001", -1) == []
+    assert StringSeries.slices("982347", 0) == []
+  end
+end
+

--- a/exercises/series/series_test.exs
+++ b/exercises/series/series_test.exs
@@ -8,6 +8,7 @@ ExUnit.configure exclude: :pending, trace: true
 defmodule StringSeriesTest do
   use ExUnit.Case
 
+  #@tag :pending
   test "slices of size 1" do
     assert StringSeries.slices("01234", 1) == ["0", "1", "2", "3", "4"]
   end

--- a/exercises/series/series_test.exs
+++ b/exercises/series/series_test.exs
@@ -8,50 +8,45 @@ ExUnit.configure exclude: :pending, trace: true
 defmodule StringSeriesTest do
   use ExUnit.Case
 
-  test "slices of 1" do
+  test "slices of size 1" do
     assert StringSeries.slices("01234", 1) == ["0", "1", "2", "3", "4"]
-    assert StringSeries.slices("92834", 1) == ["9", "2", "8", "3", "4"]
   end
 
   @tag :pending
-  test "slices of 2" do
+  test "slices of size 2" do
     assert StringSeries.slices("01234", 2) == ["01", "12", "23", "34"]
-    assert StringSeries.slices("98273463", 2) == ["98", "82", "27", "73", "34", "46", "63"]
-    assert StringSeries.slices("37103", 2) == ["37", "71", "10", "03"]
   end
 
   @tag :pending
-  test "slices of 3" do
+  test "slices of size 3" do
     assert StringSeries.slices("01234", 3) == ["012", "123", "234"]
-    assert StringSeries.slices("31001", 3) == ["310", "100", "001"]
-    assert StringSeries.slices("982347", 3) == ["982", "823", "234", "347"]
   end
 
   @tag :pending
-  test "slices of 4" do
+  test "slices of size 4" do
     assert StringSeries.slices("01234", 4) == ["0123", "1234"]
-    assert StringSeries.slices("91274", 4) == ["9127", "1274"]
   end
 
   @tag :pending
   test "slices same size as string" do
     assert StringSeries.slices("01234", 5) == ["01234"]
-    assert StringSeries.slices("31001", 5) == ["31001"]
-    assert StringSeries.slices("982347", 6) == ["982347"]
   end
 
   @tag :pending
-  test "slices bigger than string" do
+  test "Unicode characters count as a single character" do
+    assert StringSeries.slices("José", 1) == ["J", "o", "s", "é"]
+    assert StringSeries.slices("José", 2) == ["Jo", "os", "sé"]
+  end
+
+  @tag :pending
+  test "slices with size longer than string return empty list" do
     assert StringSeries.slices("01234", 6) == []
-    assert StringSeries.slices("31001", 6) == []
-    assert StringSeries.slices("982347", 7) == []
   end
 
   @tag :pending
-  test "negative-sized slices" do
-    assert StringSeries.slices("01234", -2) == []
-    assert StringSeries.slices("31001", -1) == []
-    assert StringSeries.slices("982347", 0) == []
+  test "slices with size zero or negative return empty list" do
+    assert StringSeries.slices("01234", -1) == []
+    assert StringSeries.slices("01234", 0) == []
   end
 end
 


### PR DESCRIPTION
Implementing the 'series' exercise: http://exercism.io/exercises/elixir/series

Chose to go with an empty list for slices larger than the input string size, rather than raise an error like the Ruby version, for example, since it seemed logical to say "there are no slices of size 7 in a string of size 6".