### PR TITLE
Updated change exercise to adjust to canonical data.

### DIFF
--- a/exercises/change/change.exs
+++ b/exercises/change/change.exs
@@ -2,21 +2,21 @@ defmodule Change do
   @doc """
     Determine the least number of coins to be given to the user such
     that the sum of the coins' value would equal the correct amount of change.
-    It returns :error if it is not possible to compute the right amount of coins.
-    Otherwise returns the tuple {:ok, map_of_coins}
+    It returns {:error, "cannot change"} if it is not possible to compute the
+    right amount of coins. Otherwise returns the tuple {:ok, list_of_coins}
 
     ## Examples
 
-      iex> Change.generate(3, [5, 10, 15])
-      :error
+      iex> Change.generate([5, 10, 15], 3)
+      {:error, "cannot change"}
 
-      iex> Change.generate(18, [1, 5, 10])
-      {:ok, %{1 => 3, 5 => 1, 10 => 1}}
+      iex> Change.generate([1, 5, 10], 18)
+      {:ok, [1, 1, 1, 5, 10]}
 
   """
 
-  @spec generate(integer, list) :: {:ok, map} | :error
-  def generate(amount, values) do
+  @spec generate(list, integer) :: {:ok, list} | {:error, String.t}
+  def generate(coins, target) do
 
   end
 end

--- a/exercises/change/change_test.exs
+++ b/exercises/change/change_test.exs
@@ -8,43 +8,70 @@ ExUnit.configure exclude: :pending, trace: true
 defmodule ChangeTest do
   use ExUnit.Case
 
-  test "returns :error on empty list" do
-    assert Change.generate(1, []) == :error
+  # @tag :pending
+  test "no coins make 0 change" do
+      coins = [1, 5, 10, 21, 25]
+      expected = []
+      assert Change.generate(coins, 0) == {:ok, expected}
   end
 
   @tag :pending
-  test "generates the correct change when only one coin type is needed" do
-    change = %{1 => 5, 10 => 0}
-    assert Change.generate(5, [1, 10]) == {:ok, change}
+  test "cannot find negative change values" do
+      coins = [1, 2, 5]
+      assert Change.generate(coins, -5) == {:error, "cannot change"}
   end
 
   @tag :pending
-  test "generates the correct change when multiple coin types are needed" do
-    change = %{1 => 3, 5 => 1, 10 => 1}
-    assert Change.generate(18, [1, 5, 10]) == {:ok, change}
+  test "error testing for change smaller than the smallest of coins" do
+      coins = [5, 10]
+      assert Change.generate(coins, 3) == {:error, "cannot change"}
   end
 
   @tag :pending
-  test "returns :error when it is not possible to generate change" do
-    assert Change.generate(3, [5, 10, 25]) == :error
+  test "single coin change" do
+      coins = [1, 5, 10, 25, 100]
+      expected = [25]
+      assert Change.generate(coins, 25) == {:ok, expected}
   end
 
   @tag :pending
-  test "generates change using only small coins when it is not possible to combine them with larger coins" do
-    change = %{3 => 34, 100 => 0}
-    assert Change.generate(102, [3, 100]) == {:ok, change}
+  test "multiple coin change" do
+      coins = [1, 5, 10, 25, 100]
+      expected = [5, 10]
+      assert Change.generate(coins, 15) == {:ok, expected}
+  end
+
+   @tag :pending
+   test "possible change without unit coins available" do
+      coins = [2, 5, 10, 20, 50]
+      expected = [2, 2, 2, 5, 10]
+      assert Change.generate(coins, 21) == {:ok, expected}
+   end
+
+  @tag :pending
+  test "change with Lilliputian Coins" do
+      coins = [1, 4, 15, 20, 50]
+      expected = [4, 4, 15]
+      assert Change.generate(coins, 23) == {:ok, expected}
   end
 
   @tag :pending
-  test "generates the same change given any coin order" do
-    change = %{1 => 3, 5 => 1, 10 => 1}
-    assert Change.generate(18, [1, 5, 10]) == {:ok, change}
-    assert Change.generate(18, [10, 5, 1]) == {:ok, change}
+  test "change with Lower Elbonia Coins" do
+      coins = [1, 5, 10, 21, 25]
+      expected = [21, 21, 21]
+      assert Change.generate(coins, 63) == {:ok, expected}
   end
 
   @tag :pending
-  test "generates the correct change for large values with many coins" do
-    change = %{1 => 3, 5 => 1, 10 => 0, 25 => 1, 100 => 1}
-    assert Change.generate(133, [1, 5, 10, 25, 100]) == {:ok, change}
+  test "large target values" do
+      coins = [1, 2, 5, 10, 20, 50, 100]
+      expected = [2, 2, 5, 20, 20, 50, 100, 100, 100, 100, 100, 100, 100, 100, 100]
+      assert Change.generate(coins, 999) == {:ok, expected}
+  end
+
+  @tag :pending
+  test "error if no combination can add up to target" do
+      coins = [5, 10]
+      assert Change.generate(coins, 94) == {:error, "cannot change"}
   end
 end

--- a/exercises/change/example.exs
+++ b/exercises/change/example.exs
@@ -2,35 +2,38 @@ defmodule Change do
   @doc """
     Determine the least number of coins to be given to the user such
     that the sum of the coins' value would equal the correct amount of change.
-    It returns :error if it is not possible to compute the right amount of coins.
-    Otherwise returns the tuple {:ok, map_of_coins}
+    It returns {:error, "cannot change"} if it is not possible to compute the
+    right amount of coins. Otherwise returns the tuple {:ok, list_of_coins}
 
     ## Examples
 
-      iex> Change.generate(3, [5, 10, 15])
-      :error
+      iex> Change.generate([5, 10, 15], 3)
+      {:error, "cannot change"}
 
-      iex> Change.generate(18, [1, 5, 10])
-      {:ok, %{1 => 3, 5 => 1, 10 => 1}}
+      iex> Change.generate([1, 5, 10], 18)
+      {:ok, [1, 1, 1, 5, 10]}
 
   """
 
-  @spec generate(integer, list) :: {:ok, map} | :error
-  def generate(amount, values) do
-    values |> Enum.sort(&(&2 < &1)) |> generate(amount, %{})
+  @spec generate(list, integer) :: {:ok, list} | {:error, String.t}
+  def generate(coins, target) do
+    coins |> Enum.sort(&>/2) |> generate(target, [], {:error, "cannot change"})
   end
 
-  defp generate(_, 0, acc), do: {:ok, acc}
-  defp generate([], _, _), do: :error
-  defp generate(values = [h | t], amount, acc) do
-    if amount >= h && divisible?(amount - h, values) do
-      generate(values, amount - h, Map.update(acc, h, 1, &(&1 + 1)))
-    else
-      generate(t, amount, Map.put_new(acc, h, 0))
-    end
+  defp generate(_, _, current, {:ok, best}) when length(current) >= length(best) do
+    {:ok, best}
   end
-
-  defp divisible?(num, values) do
-    Enum.any?(values, &(rem(num, &1) == 0))
+  defp generate(_, 0, current, _) do
+    {:ok, current}
+  end
+  defp generate([], _, _, best) do
+    best
+  end
+  defp generate([coin | coins], target, current, best) when coin > target do
+    generate(coins, target, current, best)
+  end
+  defp generate([coin | coins], target, current, best) do
+    first_try = generate([coin | coins], target - coin, [coin | current], best)
+    generate(coins, target, current, first_try)
   end
 end


### PR DESCRIPTION
There were some tests that differ in many ways with canonical data, like "change with Lower Elbonia Coins". That can't pass with the previous example.exs.

Furthermore, the results of canonical data are implemented with a list, not with a hash / map.

### Notes

Some tests have been lost in the migration because they aren't present in the canonical data.
This is correct? Should I add here again? Maybe in both sides?