### PR TITLE
Implement Diffie-Hellman key exchange exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -304,6 +304,13 @@
       ]
     },
     {
+      "slug": "diffie-hellman",
+      "difficulty": 4,
+      "topics": [
+        "math"
+      ]
+    },
+    {
       "slug": "sieve",
       "difficulty": 5,
       "topics": [

--- a/exercises/diffie-hellman/HINTS.md
+++ b/exercises/diffie-hellman/HINTS.md
@@ -1,0 +1,10 @@
+For generating random numbers, Erlang's `:rand.uniform` or `Enum.random` are
+good places to start.
+
+`:math.pow |> round` can be used to find the power of a number, and `rem` for
+the modulus.
+
+Neither of those works particularly well (or quickly) for very large integers.
+Cryptography generally makes use of numbers larger than 1024 bits. Erlang's
+:crypto module has a useful function for finding the modulus of a power,
+particularly for enormous integers, but you might need :binary to decode it.

--- a/exercises/diffie-hellman/diffie_hellman.exs
+++ b/exercises/diffie-hellman/diffie_hellman.exs
@@ -26,6 +26,9 @@ defmodule DiffieHellman do
   As long as their private keys are never lost or transmitted, only they know
   their private keys, so even if Eve has P, G, and both public keys, she can't
   do anything with them.
+
+  A video example is available at:
+  https://www.khanacademy.org/computing/computer-science/cryptography/modern-crypt/v/diffie-hellman-key-exchange-part-2
   """
 
   @doc """

--- a/exercises/diffie-hellman/diffie_hellman.exs
+++ b/exercises/diffie-hellman/diffie_hellman.exs
@@ -1,0 +1,93 @@
+defmodule DiffieHellman do
+  @moduledoc """
+  Diffie-Hellman is a method of securely exchanging keys in a public-key
+  cryptosystem. Two users, Alice and Bob, want to share a secret between
+  themselves, while ensuring nobody else can read it.
+
+  Step 0: Alice and Bob agree on two prime numbers, P and G. An attacker, Eve,
+  can intercept these numbers, but without one of Alice or Bob's private keys,
+  we'll see Eve can't do anything useful with them.
+
+  Step 1: Alice and Bob each generate a private key between 1 and P-1.
+  P).
+
+  Step 2: Using the initial primes P and G, Alice and Bob calculate their
+  public keys by raising G to the power of their private key, then calculating
+  the modulus of that number by P. ((G**private_key) % P)
+
+  Step 3: Alice and Bob exchange public keys. Alice and Bob calculate a secret
+  shared key by raising the other's public key to the power of their private
+  key, then doing a modulus of the result by P. Due to the way modulus math
+  works, they should both generate the same shared key.
+
+  Alice calculates: (bob_public ** alice_private) % P
+  Bob calculates: (alice_public ** bob_private) % P
+
+  As long as their private keys are never lost or transmitted, only they know
+  their private keys, so even if Eve has P, G, and both public keys, she can't
+  do anything with them.
+  """
+
+  @doc """
+  Given a prime integer `prime_p`, return a random integer between 1 and `prime_p` - 1
+
+  HINT: Erlang's `:rand.uniform` is good, `Enum.random` is better
+  """
+  @spec generate_private_key(prime_p :: integer) :: integer
+  def generate_private_key(prime_p) do
+  end
+
+  @doc """
+  Given two prime integers as generators (`prime_p` and `prime_g`), and a private key,
+  generate a public key using the mathematical formula:
+
+  (prime_g **  private_key) % prime_p
+  """
+  @spec generate_public_key(prime_p :: integer, prime_g :: integer, private_key :: integer) :: integer
+  def generate_public_key(prime_p, prime_g, private_key) do
+  end
+
+  @doc """
+  Given a prime integer `prime_p`, user B's public key, and user A's private key,
+  generate a shared secret using the mathematical formula:
+
+  (public_key_b ** private_key_a) % prime_p
+  """
+  @spec generate_shared_secret(prime_p :: integer, public_key_b :: integer, private_key_a :: integer) :: integer
+  def generate_shared_secret(prime_p, public_key_b, private_key_a) do
+  end
+end
+
+defmodule Helpers do
+  use Bitwise
+
+  @moduledoc """
+  You'll have to do a couple of functions of the form `(A ** B) % C`.
+
+  If you're reading this far down, you've probably run into the fact that
+  while Elixir supports arbitrarily large integers, Erlang's `:math.pow`
+  fails at a surprisingly low exponent (try `:math.pow(2, 10000)`). Modern
+  cryptosystems typically deal with numbers in or over the 1024-bit range,
+  so a naive approach will take a LONG time.
+
+  Fortunately, smarter people have figured out the math necessary to do
+  modular exponentiation on enormous integers well before the heat death
+  of the universe:
+
+  https://en.wikipedia.org/wiki/Modular_exponentiation#Right-to-left_binary_method
+  """
+
+  @doc """
+  Raise `base` to the power `exp`, then modulus by `mod`.
+
+  Derived from pseudocode based on Applied Cryptography by Bruce Schneier, found
+  in the Wikipedia link above.
+  """
+  def mod_pow(_base, _exp, 1), do: 0
+  def mod_pow(base, exp, mod), do: do_mod_pow(rem(base, mod), exp, mod, 1)
+
+  defp do_mod_pow(_base, exp, _mod, result) when exp <= 0, do: result
+  defp do_mod_pow(base, exp, mod, result) when rem(exp, 2) == 1, do: do_mod_pow(rem(base*base, mod), exp >>> 1, mod, rem(result * base, mod))
+  defp do_mod_pow(base, exp, mod, result), do: do_mod_pow(rem(base*base, mod), exp >>> 1, mod, result)
+end
+

--- a/exercises/diffie-hellman/diffie_hellman.exs
+++ b/exercises/diffie-hellman/diffie_hellman.exs
@@ -33,8 +33,6 @@ defmodule DiffieHellman do
 
   @doc """
   Given a prime integer `prime_p`, return a random integer between 1 and `prime_p` - 1
-
-  HINT: Erlang's `:rand.uniform` or `Enum.random` are good places to start
   """
   @spec generate_private_key(prime_p :: integer) :: integer
   def generate_private_key(prime_p) do
@@ -45,9 +43,6 @@ defmodule DiffieHellman do
   generate a public key using the mathematical formula:
 
   (prime_g **  private_key) % prime_p
-
-  HINT: Erlang's :crypto module has a useful function for finding the modulus of a power,
-  particularly for enormous integers, but you might need :binary to decode it.
   """
   @spec generate_public_key(prime_p :: integer, prime_g :: integer, private_key :: integer) :: integer
   def generate_public_key(prime_p, prime_g, private_key) do

--- a/exercises/diffie-hellman/diffie_hellman.exs
+++ b/exercises/diffie-hellman/diffie_hellman.exs
@@ -34,7 +34,7 @@ defmodule DiffieHellman do
   @doc """
   Given a prime integer `prime_p`, return a random integer between 1 and `prime_p` - 1
 
-  HINT: Erlang's `:rand.uniform` is good, `Enum.random` is better
+  HINT: Erlang's `:rand.uniform` or `Enum.random` are good places to start
   """
   @spec generate_private_key(prime_p :: integer) :: integer
   def generate_private_key(prime_p) do
@@ -45,6 +45,9 @@ defmodule DiffieHellman do
   generate a public key using the mathematical formula:
 
   (prime_g **  private_key) % prime_p
+
+  HINT: Erlang's :crypto module has a useful function for finding the modulus of a power,
+  particularly for enormous integers, but you might need :binary to decode it.
   """
   @spec generate_public_key(prime_p :: integer, prime_g :: integer, private_key :: integer) :: integer
   def generate_public_key(prime_p, prime_g, private_key) do
@@ -59,38 +62,5 @@ defmodule DiffieHellman do
   @spec generate_shared_secret(prime_p :: integer, public_key_b :: integer, private_key_a :: integer) :: integer
   def generate_shared_secret(prime_p, public_key_b, private_key_a) do
   end
-end
-
-defmodule Helpers do
-  use Bitwise
-
-  @moduledoc """
-  You'll have to do a couple of functions of the form `(A ** B) % C`.
-
-  If you're reading this far down, you've probably run into the fact that
-  while Elixir supports arbitrarily large integers, Erlang's `:math.pow`
-  fails at a surprisingly low exponent (try `:math.pow(2, 10000)`). Modern
-  cryptosystems typically deal with numbers in or over the 1024-bit range,
-  so a naive approach will take a LONG time.
-
-  Fortunately, smarter people have figured out the math necessary to do
-  modular exponentiation on enormous integers well before the heat death
-  of the universe:
-
-  https://en.wikipedia.org/wiki/Modular_exponentiation#Right-to-left_binary_method
-  """
-
-  @doc """
-  Raise `base` to the power `exp`, then modulus by `mod`.
-
-  Derived from pseudocode based on Applied Cryptography by Bruce Schneier, found
-  in the Wikipedia link above.
-  """
-  def mod_pow(_base, _exp, 1), do: 0
-  def mod_pow(base, exp, mod), do: do_mod_pow(rem(base, mod), exp, mod, 1)
-
-  defp do_mod_pow(_base, exp, _mod, result) when exp <= 0, do: result
-  defp do_mod_pow(base, exp, mod, result) when rem(exp, 2) == 1, do: do_mod_pow(rem(base*base, mod), exp >>> 1, mod, rem(result * base, mod))
-  defp do_mod_pow(base, exp, mod, result), do: do_mod_pow(rem(base*base, mod), exp >>> 1, mod, result)
 end
 

--- a/exercises/diffie-hellman/diffie_hellman_test.exs
+++ b/exercises/diffie-hellman/diffie_hellman_test.exs
@@ -9,33 +9,34 @@ defmodule DiffieHellmanTest do
   use ExUnit.Case
 
   #@tag :pending
-  test "private key should be random between 1 and P-1, inclusive" do
+  test "private key should be between 1 and P-1, inclusive" do
     prime_p = 23
 
-    generated_private_keys = 1..100 |> Enum.map(fn _i -> DiffieHellman.generate_private_key(prime_p) end)
-
-    all_keys_in_range = generated_private_keys |> Enum.all?(fn pk -> pk > 0 and pk < prime_p end)
-
-    assert all_keys_in_range == true
-
-    # Due to the nature of random generators, there's a small chance it could generate
-    # the same numbers over an over, so this may fail, but the RNG should be good enough
-    # that 100 generated keys between 1 and 22 ought to be at least half unique.
-    min_expected_unique_keys = div(prime_p, 2)
-    actual_unique_keys = generated_private_keys |> Enum.uniq |> length
-
-    assert actual_unique_keys > min_expected_unique_keys
+    assert DiffieHellman.generate_private_key(prime_p) in Range.new(1, prime_p-1)
   end
 
   @tag :pending
   test "private key generator should support very large primes" do
     prime_p = 120227323036150778550155526710966921740030662694578947298423549235265759593711587341037426347114541533006628856300552706996143592240453345642869233562886752930249953227657883929905072620233073626594386072962776144691433658814261874113232461749035425712805067202910389407991986070558964461330091797026762932543
 
-    generated_private_keys = 1..100 |> Enum.map(fn _i -> DiffieHellman.generate_private_key(prime_p) end)
+    assert DiffieHellman.generate_private_key(prime_p) in Range.new(1, prime_p-1)
+  end
 
-    all_keys_in_range = generated_private_keys |> Enum.all?(fn pk -> pk > 0 and pk < prime_p end)
+  @tag :pending
+  test "private keys should be random" do
+    prime_p = 23
 
-    assert all_keys_in_range == true
+    # Due to the nature of random generators, there's a small chance it could generate
+    # the same numbers over an over, so this may fail, but the RNG should be good enough
+    # that 100 generated keys between 1 and 22 ought to be at least half unique.
+
+    unique_key_count = Stream.repeatedly(fn -> DiffieHellman.generate_private_key(prime_p) end)
+                       |> Enum.take(100)
+                       |> Enum.uniq
+                       |> length
+    min_expected_unique_keys = div(prime_p, 2)
+
+    assert unique_key_count > min_expected_unique_keys
   end
 
   @tag :pending
@@ -79,7 +80,7 @@ defmodule DiffieHellmanTest do
   end
 
   @tag :pending
-  test "exchanging public keys between Alice and Bob lets them calculate the same shared secret" do
+  test "exchanging public keys between Alice and Bob should calculate the same shared secret" do
     prime_p = 23
     prime_g = 5
 

--- a/exercises/diffie-hellman/diffie_hellman_test.exs
+++ b/exercises/diffie-hellman/diffie_hellman_test.exs
@@ -1,0 +1,98 @@
+if !System.get_env("EXERCISM_TEST_EXAMPLES") do
+  Code.load_file("diffie_hellman.exs", __DIR__)
+end
+
+ExUnit.start
+ExUnit.configure exclude: :pending, trace: true
+
+defmodule DiffieHellmanTest do
+  use ExUnit.Case
+
+  #@tag :pending
+  test "private key should be random between 1 and P-1, inclusive" do
+    prime_p = 23
+
+    generated_private_keys = 1..100 |> Enum.map(fn _i -> DiffieHellman.generate_private_key(prime_p) end)
+
+    all_keys_in_range = generated_private_keys |> Enum.all?(fn pk -> pk > 0 and pk < prime_p end)
+
+    assert all_keys_in_range == true
+
+    # Due to the nature of random generators, there's a small chance it could generate
+    # the same numbers over an over, so this may fail, but the RNG should be good enough
+    # that 100 generated keys between 1 and 22 ought to be at least half unique.
+    min_expected_unique_keys = div(prime_p, 2)
+    actual_unique_keys = generated_private_keys |> Enum.uniq |> length
+
+    assert actual_unique_keys > min_expected_unique_keys
+  end
+
+  @tag :pending
+  test "private key generator should support very large primes" do
+    prime_p = 120227323036150778550155526710966921740030662694578947298423549235265759593711587341037426347114541533006628856300552706996143592240453345642869233562886752930249953227657883929905072620233073626594386072962776144691433658814261874113232461749035425712805067202910389407991986070558964461330091797026762932543
+
+    generated_private_keys = 1..100 |> Enum.map(fn _i -> DiffieHellman.generate_private_key(prime_p) end)
+
+    all_keys_in_range = generated_private_keys |> Enum.all?(fn pk -> pk > 0 and pk < prime_p end)
+
+    assert all_keys_in_range == true
+  end
+
+  @tag :pending
+  test "public key correctly calculated from two primes and private key" do
+    prime_p = 23
+    prime_g = 5
+    private_key = 6
+    expected_public_key = 8
+
+    assert DiffieHellman.generate_public_key(prime_p, prime_g, private_key) == expected_public_key
+  end
+
+  @tag :pending
+  test "public key generator should support very large primes" do
+    prime_p = 120227323036150778550155526710966921740030662694578947298423549235265759593711587341037426347114541533006628856300552706996143592240453345642869233562886752930249953227657883929905072620233073626594386072962776144691433658814261874113232461749035425712805067202910389407991986070558964461330091797026762932543
+    prime_g = 75205441154357919442925546169208711235485855904969178206313309299205868312399046149367516336607966149689640419216591714331722664409474612463910928128055994157922930443733535659848264364106037925315974095321112757711756912144137705613776063541350548911512715512539186192176020596861210448363099541947258202188
+    private_key = 8675309
+    expected_public_key = 81945102766205597052444239927191366879878802281637258134656723311532689587789695879960502348293388789700383121890410484395608064685866057972603193444399431765316092443741213175747052166212523610645396217140238838864033970876203333493173215068467082830013531737232331628864212666452277691016389511356912249174
+
+    assert DiffieHellman.generate_public_key(prime_p, prime_g, private_key) == expected_public_key
+  end
+
+  @tag :pending
+  test "shared secret key correctly calculated from initial prime, Bob's public key, and Alice's private key" do
+    prime_p = 23
+    bob_public_key = 19
+    alice_private_key = 6
+    expected_shared_secret = 2
+
+    assert DiffieHellman.generate_shared_secret(prime_p, bob_public_key, alice_private_key) == expected_shared_secret
+  end
+
+  @tag :pending
+  test "shared secret correctly calculated when using large primes" do
+    prime_p = 120227323036150778550155526710966921740030662694578947298423549235265759593711587341037426347114541533006628856300552706996143592240453345642869233562886752930249953227657883929905072620233073626594386072962776144691433658814261874113232461749035425712805067202910389407991986070558964461330091797026762932543
+    bob_public_key = 75205441154357919442925546169208711235485855904969178206313309299205868312399046149367516336607966149689640419216591714331722664409474612463910928128055994157922930443733535659848264364106037925315974095321112757711756912144137705613776063541350548911512715512539186192176020596861210448363099541947258202188
+    alice_private_key = 2483479393625932939911081304356888505153797135447327501792696199190469015215177630758617902200417377685436170904594686456961202706692908603181062371925882
+    expected_shared_secret = 70900735223964890815905879227737819348808518698920446491346508980461201746567735331455825644429877946556431095820785835497384849778344216981228226252639932672153547963980483673419756271345828771971984887453014488572245819864454136618980914729839523581263886740821363010486083940557620831348661126601106717071
+
+    assert DiffieHellman.generate_shared_secret(prime_p, bob_public_key, alice_private_key) == expected_shared_secret
+  end
+
+  @tag :pending
+  test "exchanging public keys between Alice and Bob lets them calculate the same shared secret" do
+    prime_p = 23
+    prime_g = 5
+
+    alice_private_key = DiffieHellman.generate_private_key(prime_p)
+    bob_private_key = DiffieHellman.generate_private_key(prime_p)
+
+    alice_public_key = DiffieHellman.generate_public_key(prime_p, prime_g, alice_private_key)
+    bob_public_key = DiffieHellman.generate_public_key(prime_p, prime_g, bob_private_key)
+
+    alice_shared_secret = DiffieHellman.generate_shared_secret(prime_p, bob_public_key, alice_private_key)
+    bob_shared_secret = DiffieHellman.generate_shared_secret(prime_p, alice_public_key, bob_private_key)
+
+    assert alice_shared_secret == bob_shared_secret
+  end
+end
+

--- a/exercises/diffie-hellman/example.exs
+++ b/exercises/diffie-hellman/example.exs
@@ -26,6 +26,9 @@ defmodule DiffieHellman do
   As long as their private keys are never lost or transmitted, only they know
   their private keys, so even if Eve has P, G, and both public keys, she can't
   do anything with them.
+
+  A video example is available at:
+  https://www.khanacademy.org/computing/computer-science/cryptography/modern-crypt/v/diffie-hellman-key-exchange-part-2
   """
 
   @doc """

--- a/exercises/diffie-hellman/example.exs
+++ b/exercises/diffie-hellman/example.exs
@@ -1,0 +1,96 @@
+defmodule DiffieHellman do
+  @moduledoc """
+  Diffie-Hellman is a method of securely exchanging keys in a public-key
+  cryptosystem. Two users, Alice and Bob, want to share a secret between
+  themselves, while ensuring nobody else can read it.
+
+  Step 0: Alice and Bob agree on two prime numbers, P and G. An attacker, Eve,
+  can intercept these numbers, but without one of Alice or Bob's private keys,
+  we'll see Eve can't do anything useful with them.
+
+  Step 1: Alice and Bob each generate a private key between 1 and P-1.
+  P).
+
+  Step 2: Using the initial primes P and G, Alice and Bob calculate their
+  public keys by raising G to the power of their private key, then calculating
+  the modulus of that number by P. ((G**private_key) % P)
+
+  Step 3: Alice and Bob exchange public keys. Alice and Bob calculate a secret
+  shared key by raising the other's public key to the power of their private
+  key, then doing a modulus of the result by P. Due to the way modulus math
+  works, they should both generate the same shared key.
+
+  Alice calculates: (bob_public ** alice_private) % P
+  Bob calculates: (alice_public ** bob_private) % P
+
+  As long as their private keys are never lost or transmitted, only they know
+  their private keys, so even if Eve has P, G, and both public keys, she can't
+  do anything with them.
+  """
+
+  @doc """
+  Given a prime integer `prime_p`, return a random integer between 1 and `prime_p` - 1
+
+  HINT: Erlang's `:rand.uniform` is good, `Enum.random` is better
+  """
+  @spec generate_private_key(prime_p :: integer) :: integer
+  def generate_private_key(prime_p) do
+    1 |> Range.new(prime_p - 1) |> Enum.random
+  end
+
+  @doc """
+  Given two prime integers as generators (`prime_p` and `prime_g`), and a private key,
+  generate a public key using the mathematical formula:
+
+  (prime_g **  private_key) % prime_p
+  """
+  @spec generate_public_key(prime_p :: integer, prime_g :: integer, private_key :: integer) :: integer
+  def generate_public_key(prime_p, prime_g, private_key) do
+    Helpers.mod_pow(prime_g, private_key, prime_p)
+  end
+
+  @doc """
+  Given a prime integer `prime_p`, user B's public key, and user A's private key,
+  generate a shared secret using the mathematical formula:
+
+  (public_key_b ** private_key_a) % prime_p
+  """
+  @spec generate_shared_secret(prime_p :: integer, public_key_b :: integer, private_key_a :: integer) :: integer
+  def generate_shared_secret(prime_p, public_key_b, private_key_a) do
+    Helpers.mod_pow(public_key_b, private_key_a, prime_p)
+  end
+end
+
+defmodule Helpers do
+  use Bitwise
+
+  @moduledoc """
+  You'll have to do a couple of functions of the form `(A ** B) % C`.
+
+  If you're reading this far down, you've probably run into the fact that
+  while Elixir supports arbitrarily large integers, Erlang's `:math.pow`
+  fails at a surprisingly low exponent (try `:math.pow(2, 10000)`). Modern
+  cryptosystems typically deal with numbers in or over the 1024-bit range,
+  so a naive approach will take a LONG time.
+
+  Fortunately, smarter people have figured out the math necessary to do
+  modular exponentiation on enormous integers well before the heat death
+  of the universe:
+
+  https://en.wikipedia.org/wiki/Modular_exponentiation#Right-to-left_binary_method
+  """
+
+  @doc """
+  Raise `base` to the power `exp`, then modulus by `mod`.
+
+  Derived from pseudocode based on Applied Cryptography by Bruce Schneier, found
+  in the Wikipedia link above.
+  """
+  def mod_pow(_base, _exp, 1), do: 0
+  def mod_pow(base, exp, mod), do: do_mod_pow(rem(base, mod), exp, mod, 1)
+
+  defp do_mod_pow(_base, exp, _mod, result) when exp <= 0, do: result
+  defp do_mod_pow(base, exp, mod, result) when rem(exp, 2) == 1, do: do_mod_pow(rem(base*base, mod), exp >>> 1, mod, rem(result * base, mod))
+  defp do_mod_pow(base, exp, mod, result), do: do_mod_pow(rem(base*base, mod), exp >>> 1, mod, result)
+end
+

--- a/exercises/diffie-hellman/example.exs
+++ b/exercises/diffie-hellman/example.exs
@@ -33,8 +33,6 @@ defmodule DiffieHellman do
 
   @doc """
   Given a prime integer `prime_p`, return a random integer between 1 and `prime_p` - 1
-
-  HINT: Erlang's `:rand.uniform` or `Enum.random` are good places to start
   """
   @spec generate_private_key(prime_p :: integer) :: integer
   def generate_private_key(prime_p) do
@@ -46,9 +44,6 @@ defmodule DiffieHellman do
   generate a public key using the mathematical formula:
 
   (prime_g **  private_key) % prime_p
-
-  HINT: Erlang's :crypto module has a useful function for finding the modulus of a power,
-  particularly for enormous integers, but you might need :binary to decode it.
   """
   @spec generate_public_key(prime_p :: integer, prime_g :: integer, private_key :: integer) :: integer
   def generate_public_key(prime_p, prime_g, private_key) do


### PR DESCRIPTION
I'm not sure what the policy on helper modules/functions is, but after attempting to duplicate the C#, F#, and Go tests, I realized that doing (A^B)%C with 1024-bit numbers is incredibly slow, despite Elixir's support for arbitrarily large integers. Left it running for 2 days, no signs of stopping.

Attempted to use https://en.wikipedia.org/wiki/Modular_exponentiation#Memory-efficient_method for the functionality, with a few `IO.inspect`s thrown in, and that one literally runs `B` times, so for numbers so big we don't officially have names for them, it was going to take awhile. The method right below that one, however, does some fancy math I wouldn't expect users to try to figure out, but runs almost instantaneously, so I included it, and enough documentation of how D-H works that it'd push the `Helper` module off the bottom of most editors, and hopefully they'll try `A |> :math.pow(B) |> round |> rem(C)` first.

Alternatively, I could remove the very large integer tests, but the other implementations have them with built-in functions that didn't exist in Elixir, and I think they're useful in understanding cryptography.