### PR TITLE
2 unit tests to enfroce handling of whitespace

### DIFF
--- a/exercises/run-length-encoding/example.exs
+++ b/exercises/run-length-encoding/example.exs
@@ -2,15 +2,11 @@ defmodule RunLengthEncoder do
 
   @spec encode(String.t) :: String.t
   def encode(string) do
-    Regex.scan(~r/([a-zA-Z ])\1*/, string)
+    Regex.scan(~r/([a-zA-Z\s])\1*/, string)
     |> Enum.map_join(fn([run, c]) ->
-      if String.match?(run, ~r/\s+/) do
-        run
-      else
-        times = String.length(run)
-        number = if times == 1 do "" else times end
-          "#{number}#{c}"
-      end
+      times = String.length(run)
+      number = if times == 1 do "" else times end
+        "#{number}#{c}"
     end)
   end
 

--- a/exercises/run-length-encoding/rle_test.exs
+++ b/exercises/run-length-encoding/rle_test.exs
@@ -13,8 +13,28 @@ defmodule RunLengthEncoderTest do
   end
 
   @tag :pending
-  test "encode single characters only" do
+  test "encode single characters only are encoded without count" do
     assert RunLengthEncoder.encode("XYZ") === "XYZ"
+  end
+
+  @tag :pending
+  test "encode string with no single characters" do
+    assert RunLengthEncoder.encode("AABBBCCCC") == "2A3B4C"
+  end
+
+  @tag :pending
+  test "encode single characters mixed with repeated characters" do
+    assert RunLengthEncoder.encode("WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB") === "12WB12W3B24WB"
+  end
+
+  @tag :pending
+  test "encode multiple whitespace mixed in string" do
+    assert RunLengthEncoder.encode("  hsqq qww  ") === "2 hs2q q2w2 "
+  end
+
+  @tag :pending
+  test "encode lowercase characters" do
+    assert RunLengthEncoder.encode("aabbbcccc") === "2a3b4c"
   end
 
   @tag :pending
@@ -28,37 +48,27 @@ defmodule RunLengthEncoderTest do
   end
 
   @tag :pending
-  test "encode simple" do
-    assert RunLengthEncoder.encode("AABBBCCCC") == "2A3B4C"
-  end
-
-  @tag :pending
-  test "decode simple" do
+  test "decode string with no single characters" do
     assert RunLengthEncoder.decode("2A3B4C") == "AABBBCCCC"
   end
 
   @tag :pending
-  test "encode with single values" do
-    assert RunLengthEncoder.encode("WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB") === "12WB12W3B24WB"
-  end
-
-  @tag :pending
-  test "decode with single values" do
+  test "decode single characters with repeated characters" do
     assert RunLengthEncoder.decode("12WB12W3B24WB") === "WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB"
   end
 
   @tag :pending
-  test "encode with whitespace kept intact" do
-    assert RunLengthEncoder.encode("AA BB  CDDD") === "2A 2B  C3D"
+  test "decode multiple whitespace mixed in string" do
+    assert RunLengthEncoder.decode("2 hs2q q2w2 ") === "  hsqq qww  "
   end
 
   @tag :pending
-  test "decode with whitespace" do
-    assert RunLengthEncoder.decode("2A 2B  C3D") === "AA BB  CDDD"
+  test "decode lower case string" do
+    assert RunLengthEncoder.decode("2a3b4c") === "aabbbcccc"
   end
 
   @tag :pending
-  test "decode(encode(...)) combination" do
+  test "consistency encode followed by decode gives original string" do
     original = "zzz ZZ  zZ"
     encoded = RunLengthEncoder.encode(original)
     assert RunLengthEncoder.decode(encoded) === original

--- a/exercises/run-length-encoding/rle_test.exs
+++ b/exercises/run-length-encoding/rle_test.exs
@@ -48,6 +48,16 @@ defmodule RunLengthEncoderTest do
   end
 
   @tag :pending
+  test "encode with whitespace kept intact" do
+    assert RunLengthEncoder.encode("AA BB  CDDD") === "2A 2B  C3D"
+  end
+
+  @tag :pending
+  test "decode with whitespace" do
+    assert RunLengthEncoder.decode("2A 2B  C3D") === "AA BB  CDDD"
+  end
+
+  @tag :pending
   test "decode(encode(...)) combination" do
     original = "zzz ZZ  zZ"
     encoded = RunLengthEncoder.encode(original)

--- a/exercises/run-length-encoding/rle_test.exs
+++ b/exercises/run-length-encoding/rle_test.exs
@@ -68,7 +68,7 @@ defmodule RunLengthEncoderTest do
   end
 
   @tag :pending
-  test "consistency encode followed by decode gives original string" do
+  test "encode followed by decode gives original string" do
     original = "zzz ZZ  zZ"
     encoded = RunLengthEncoder.encode(original)
     assert RunLengthEncoder.decode(encoded) === original


### PR DESCRIPTION
The README file for the run-length-encoding exercise has this line: 
> If the string contains any whitespace, it should be passed through unchanged

However, there's no unit test to enforce this rule. The `decode(encode(...)) combination` test doesn't quite cut it because cycling accepts encoded spaces as long as the resulting string gets decoded properly.

The example implementation passes these two new tests without any changes.