### PR TITLE
Implement scale-generator exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -259,6 +259,14 @@
       ]
     },
     {
+      "slug": "scale-generator",
+      "difficulty": 5,
+      "topics": [
+        "enumerations",
+        "string processing"
+      ]
+    },
+    {
       "slug": "luhn",
       "difficulty": 5,
       "topics": [

--- a/exercises/scale-generator/example.exs
+++ b/exercises/scale-generator/example.exs
@@ -4,7 +4,7 @@ defmodule ScaleGenerator do
   @flat_keys ~w(F Bb Eb Ab Db Gb d g c f bb eb)
 
   @doc """
-  Find the note a given interval (`step`) in `scale` after the `tonic`.
+  Find the note for a given interval (`step`) in a `scale` after the `tonic`.
 
   "m": one semitone
   "M": two semitones (full tone)

--- a/exercises/scale-generator/example.exs
+++ b/exercises/scale-generator/example.exs
@@ -1,35 +1,87 @@
 defmodule ScaleGenerator do
+  @chromatic_scale ~w(C C# D D# E F F# G G# A A# B)
+  @flat_chromatic_scale ~w(C Db D Eb E F Gb G Ab A Bb B)
+  @flat_keys ~w(F Bb Eb Ab Db Gb d g c f bb eb)
+
   @doc """
   The chromatic scale is a musical scale with twelve pitches, each a semitone
   (half-tone) above or below another.
 
-  C C# D D# E F F# G G# A A# B
+  Notes with a sharp (#) are a semitone higher than the note below them, where
+  the next letter note is a full tone except in the case of B and E, which have
+  no sharps.
 
-  Notes with a sharp (#) are half a tone (a semitone) higher than the note
-  below them, where the next letter note is a full tone except in the case of B
-  and E, which have no sharps.
+  Generate these 12 notes, starting with the given `tonic` and wrapping back
+  around to the note before it. If the `tonic` is lowercase, capitalize it.
 
+  "C" should generate: ~w(C C# D D# E F F# G G# A A# B)
+  """
+  @spec chromatic_scale(tonic :: String.t()) :: list(String.t())
+  def chromatic_scale(tonic \\ "C") do
+    tonic
+    |> String.capitalize
+    |> rotate_scale(@chromatic_scale)
+  end
+
+  @doc """
   Sharp notes can also be considered the flat (b) note of the tone above them,
-  so the chromatic scale above can also be represented as:
+  so the 12 notes can also be represented as:
 
-  C Db D Eb E F Gb G Ab A Bb B
+  A Bb B C Db D Eb E F Gb G Ab
 
+  Generate these 12 notes, starting with the given `tonic` and wrapping back
+  around to the note before it. If the `tonic` is lowercase, capitalize it.
+
+  "C" should generate: ~w(C Db D Eb E F Gb G Ab A Bb B)
+  """
+  @spec flat_chromatic_scale(tonic :: String.t()) :: list(String.t())
+  def flat_chromatic_scale(tonic \\ "C") do
+    tonic
+    |> String.capitalize
+    |> rotate_scale(@flat_chromatic_scale)
+  end
+
+  defp rotate_scale(tonic, scale, temp \\ [])
+  defp rotate_scale(tonic, [tonic | _] = scale_from_tonic, temp), do: scale_from_tonic ++ temp
+  defp rotate_scale(tonic, [head | tail], temp), do: rotate_scale(tonic, tail, temp ++ [head])
+
+  @doc """
   Certain scales will require the use of the flat version, depending on the
   `tonic` (key) that begins them, which is C in the above examples.
 
-  If you are asked to find a scale for any of the following tonics, use the
-  flat chromatic scale:
+  For any of the following tonics, use the flat chromatic scale:
 
   F Bb Eb Ab Db Gb d g c f bb eb
 
   For all others, use the regular chromatic scale.
+  """
+  @spec find_chromatic_scale(tonic :: String.t()) :: list(String.t())
+  for flat_tonic <- @flat_keys do
+    def find_chromatic_scale(unquote(flat_tonic)), do: flat_chromatic_scale(unquote(flat_tonic |> String.capitalize))
+  end
+  def find_chromatic_scale(tonic) do
+    chromatic_scale(tonic)
+  end
 
-  The `pattern` string will let you know how many semitones to step over to get
-  the next note in your scale:
+  @doc """
+  Find the note a given interval (`step`) in `scale` after the `tonic`.
 
   "m": one semitone
   "M": two semitones (full tone)
   "A": augmented second (three semitones)
+  """
+  @spec step(scale :: list(String.t()), tonic :: String.t(), step :: String.t()) :: list(String.t())
+  def step(scale, tonic, step) do
+    tonic |> rotate_scale(scale) |> do_step(step)
+  end
+
+  defp do_step([_tonic, semitone, _full_tone | _], "m"), do: semitone
+  defp do_step([_tonic, _semitone, full_tone | _], "M"), do: full_tone
+  defp do_step([_tonic, _semitone, _full_tone, accidental | _], "A"), do: accidental
+
+  @doc """
+  The `pattern` string will let you know how many steps to make for the next
+  note in the scale.
 
   For example, a C Major scale will receive the pattern "MMmMMMm", which
   indicates you will start with C, make a full step over C# to D, another over
@@ -37,42 +89,18 @@ defmodule ScaleGenerator do
   can follow the rest of the pattern to get:
 
   C D E F G A B C
-
-  For the purposes of these exercises, we don't repeat the tonic, so after you
-  have found your 12 notes starting with your tonic, once you run out of notes,
-  you can stop, leaving you with:
-
-  C D E F G A B
   """
   @spec scale(tonic :: String.t(), pattern :: String.t()) :: list(String.t())
   def scale(tonic, pattern) do
     tonic
-    |> find_scale
-    |> find_notes(pattern, [])
+    |> find_chromatic_scale
+    |> generate_scale(pattern, [tonic |> String.capitalize])
   end
 
-  @chromatic_scale ~w(C C# D D# E F F# G G# A A# B)
-  @flat_chromatic_scale ~w(C Db D Eb E F Gb G Ab A Bb B)
-  @flat_keys ~w(F Bb Eb Ab Db Gb d g c f bb eb)
-
-  for ([tonic | _] = scale) <- @chromatic_scale |> Stream.cycle |> Stream.chunk(12, 1) |> Enum.take(12) do
-    defp chromatic_scale_for_tonic(unquote(tonic)), do: unquote(scale)
-    defp chromatic_scale_for_tonic(unquote(tonic |> String.downcase)), do: unquote(scale)
+  defp generate_scale(scale, pattern, results)
+  defp generate_scale(_scale, "", results), do: Enum.reverse(results)
+  defp generate_scale(scale, <<step_amt::binary-size(1), pattern::binary>>, [last_tonic | _] = results) do
+    generate_scale(scale, pattern, [step(scale, last_tonic, step_amt) | results])
   end
-
-  for ([tonic | _] = scale) <- @flat_chromatic_scale |> Stream.cycle |> Stream.chunk(12, 1) |> Enum.take(12) do
-    defp flat_chromatic_scale_for_tonic(unquote(tonic)), do: unquote(scale)
-    defp flat_chromatic_scale_for_tonic(unquote(tonic |> String.downcase)), do: unquote(scale)
-  end
-
-  for flat_tonic <- @flat_keys do
-    defp find_scale(unquote(flat_tonic)), do: flat_chromatic_scale_for_tonic(unquote(flat_tonic))
-  end
-  defp find_scale(tonic), do: chromatic_scale_for_tonic(tonic)
-
-  defp find_notes([], _, results), do: Enum.reverse(results)
-  defp find_notes([note, _, _ | notes], "A" <> pattern, results), do: find_notes(notes, pattern, [note | results])
-  defp find_notes([note, _ | notes], "M" <> pattern, results), do: find_notes(notes, pattern, [note | results])
-  defp find_notes([note | notes], "m" <> pattern, results), do: find_notes(notes, pattern, [note | results])
 end
 

--- a/exercises/scale-generator/example.exs
+++ b/exercises/scale-generator/example.exs
@@ -1,0 +1,78 @@
+defmodule ScaleGenerator do
+  @doc """
+  The chromatic scale is a musical scale with twelve pitches, each a semitone
+  (half-tone) above or below another.
+
+  C C# D D# E F F# G G# A A# B
+
+  Notes with a sharp (#) are half a tone (a semitone) higher than the note
+  below them, where the next letter note is a full tone except in the case of B
+  and E, which have no sharps.
+
+  Sharp notes can also be considered the flat (b) note of the tone above them,
+  so the chromatic scale above can also be represented as:
+
+  C Db D Eb E F Gb G Ab A Bb B
+
+  Certain scales will require the use of the flat version, depending on the
+  `tonic` (key) that begins them, which is C in the above examples.
+
+  If you are asked to find a scale for any of the following tonics, use the
+  flat chromatic scale:
+
+  F Bb Eb Ab Db Gb d g c f bb eb
+
+  For all others, use the regular chromatic scale.
+
+  The `pattern` string will let you know how many semitones to step over to get
+  the next note in your scale:
+
+  "m": one semitone
+  "M": two semitones (full tone)
+  "A": augmented second (three semitones)
+
+  For example, a C Major scale will receive the pattern "MMmMMMm", which
+  indicates you will start with C, make a full step over C# to D, another over
+  D# to E, then a semitone, stepping from E to F (again, E has no sharp). You
+  can follow the rest of the pattern to get:
+
+  C D E F G A B C
+
+  For the purposes of these exercises, we don't repeat the tonic, so after you
+  have found your 12 notes starting with your tonic, once you run out of notes,
+  you can stop, leaving you with:
+
+  C D E F G A B
+  """
+  @spec scale(tonic :: String.t(), pattern :: String.t()) :: list(String.t())
+  def scale(tonic, pattern) do
+    tonic
+    |> find_scale
+    |> find_notes(pattern, [])
+  end
+
+  @chromatic_scale ~w(C C# D D# E F F# G G# A A# B)
+  @flat_chromatic_scale ~w(C Db D Eb E F Gb G Ab A Bb B)
+  @flat_keys ~w(F Bb Eb Ab Db Gb d g c f bb eb)
+
+  for ([tonic | _] = scale) <- @chromatic_scale |> Stream.cycle |> Stream.chunk(12, 1) |> Enum.take(12) do
+    defp chromatic_scale_for_tonic(unquote(tonic)), do: unquote(scale)
+    defp chromatic_scale_for_tonic(unquote(tonic |> String.downcase)), do: unquote(scale)
+  end
+
+  for ([tonic | _] = scale) <- @flat_chromatic_scale |> Stream.cycle |> Stream.chunk(12, 1) |> Enum.take(12) do
+    defp flat_chromatic_scale_for_tonic(unquote(tonic)), do: unquote(scale)
+    defp flat_chromatic_scale_for_tonic(unquote(tonic |> String.downcase)), do: unquote(scale)
+  end
+
+  for flat_tonic <- @flat_keys do
+    defp find_scale(unquote(flat_tonic)), do: flat_chromatic_scale_for_tonic(unquote(flat_tonic))
+  end
+  defp find_scale(tonic), do: chromatic_scale_for_tonic(tonic)
+
+  defp find_notes([], _, results), do: Enum.reverse(results)
+  defp find_notes([note, _, _ | notes], "A" <> pattern, results), do: find_notes(notes, pattern, [note | results])
+  defp find_notes([note, _ | notes], "M" <> pattern, results), do: find_notes(notes, pattern, [note | results])
+  defp find_notes([note | notes], "m" <> pattern, results), do: find_notes(notes, pattern, [note | results])
+end
+

--- a/exercises/scale-generator/scale_generator.exs
+++ b/exercises/scale-generator/scale_generator.exs
@@ -1,0 +1,51 @@
+defmodule ScaleGenerator do
+  @doc """
+  The chromatic scale is a musical scale with twelve pitches, each a semitone
+  (half-tone) above or below another.
+
+  C C# D D# E F F# G G# A A# B
+
+  Notes with a sharp (#) are half a tone (a semitone) higher than the note
+  below them, where the next letter note is a full tone except in the case of B
+  and E, which have no sharps.
+
+  Sharp notes can also be considered the flat (b) note of the tone above them,
+  so the chromatic scale above can also be represented as:
+
+  C Db D Eb E F Gb G Ab A Bb B
+
+  Certain scales will require the use of the flat version, depending on the
+  `tonic` (key) that begins them, which is C in the above examples.
+
+  If you are asked to find a scale for any of the following tonics, use the
+  flat chromatic scale:
+
+  F Bb Eb Ab Db Gb d g c f bb eb
+
+  For all others, use the regular chromatic scale.
+
+  The `pattern` string will let you know how many semitones to step over to get
+  the next note in your scale:
+
+  "m": one semitone
+  "M": two semitones (full tone)
+  "A": augmented second (three semitones)
+
+  For example, a C Major scale will receive the pattern "MMmMMMm", which
+  indicates you will start with C, make a full step over C# to D, another over
+  D# to E, then a semitone, stepping from E to F (again, E has no sharp). You
+  can follow the rest of the pattern to get:
+
+  C D E F G A B C
+
+  For the purposes of these exercises, we don't repeat the tonic, so after you
+  have found your 12 notes starting with your tonic, once you run out of notes,
+  you can stop, leaving you with:
+
+  C D E F G A B
+  """
+  @spec scale(tonic :: String.t(), pattern :: String.t()) :: list(String.t())
+  def scale(tonic, pattern) do
+  end
+end
+

--- a/exercises/scale-generator/scale_generator.exs
+++ b/exercises/scale-generator/scale_generator.exs
@@ -3,33 +3,62 @@ defmodule ScaleGenerator do
   The chromatic scale is a musical scale with twelve pitches, each a semitone
   (half-tone) above or below another.
 
-  C C# D D# E F F# G G# A A# B
+  Notes with a sharp (#) are a semitone higher than the note below them, where
+  the next letter note is a full tone except in the case of B and E, which have
+  no sharps.
 
-  Notes with a sharp (#) are half a tone (a semitone) higher than the note
-  below them, where the next letter note is a full tone except in the case of B
-  and E, which have no sharps.
+  Generate these 12 notes, starting with the given `tonic` and wrapping back
+  around to the note before it. If the `tonic` is lowercase, capitalize it.
 
+  "C" should generate: ~w(C C# D D# E F F# G G# A A# B)
+  """
+  @spec chromatic_scale(tonic :: String.t()) :: list(String.t())
+  def chromatic_scale(tonic \\ "C") do
+  end
+
+  @doc """
   Sharp notes can also be considered the flat (b) note of the tone above them,
-  so the chromatic scale above can also be represented as:
+  so the 12 notes can also be represented as:
 
-  C Db D Eb E F Gb G Ab A Bb B
+  A Bb B C Db D Eb E F Gb G Ab
 
+  Generate these 12 notes, starting with the given `tonic` and wrapping back
+  around to the note before it. If the `tonic` is lowercase, capitalize it.
+
+  "C" should generate: ~w(C Db D Eb E F Gb G Ab A Bb B)
+  """
+  @spec flat_chromatic_scale(tonic :: String.t()) :: list(String.t())
+  def flat_chromatic_scale(tonic \\ "C") do
+  end
+
+  @doc """
   Certain scales will require the use of the flat version, depending on the
   `tonic` (key) that begins them, which is C in the above examples.
 
-  If you are asked to find a scale for any of the following tonics, use the
-  flat chromatic scale:
+  For any of the following tonics, use the flat chromatic scale:
 
   F Bb Eb Ab Db Gb d g c f bb eb
 
   For all others, use the regular chromatic scale.
+  """
+  @spec find_chromatic_scale(tonic :: String.t()) :: list(String.t())
+  def find_chromatic_scale(tonic) do
+  end
 
-  The `pattern` string will let you know how many semitones to step over to get
-  the next note in your scale:
+  @doc """
+  Find the note a given interval (`step`) in `scale` after the `tonic`.
 
   "m": one semitone
   "M": two semitones (full tone)
   "A": augmented second (three semitones)
+  """
+  @spec step(scale :: list(String.t()), tonic :: String.t(), step :: String.t()) :: list(String.t())
+  def step(scale, tonic, step) do
+  end
+
+  @doc """
+  The `pattern` string will let you know how many steps to make for the next
+  note in the scale.
 
   For example, a C Major scale will receive the pattern "MMmMMMm", which
   indicates you will start with C, make a full step over C# to D, another over
@@ -37,12 +66,6 @@ defmodule ScaleGenerator do
   can follow the rest of the pattern to get:
 
   C D E F G A B C
-
-  For the purposes of these exercises, we don't repeat the tonic, so after you
-  have found your 12 notes starting with your tonic, once you run out of notes,
-  you can stop, leaving you with:
-
-  C D E F G A B
   """
   @spec scale(tonic :: String.t(), pattern :: String.t()) :: list(String.t())
   def scale(tonic, pattern) do

--- a/exercises/scale-generator/scale_generator.exs
+++ b/exercises/scale-generator/scale_generator.exs
@@ -1,16 +1,35 @@
 defmodule ScaleGenerator do
   @doc """
-  The chromatic scale is a musical scale with twelve pitches, each a semitone
+  Find the note a given interval (`step`) in `scale` after the `tonic`.
+
+  "m": one semitone
+  "M": two semitones (full tone)
+  "A": augmented second (three semitones)
+
+  Given the `tonic` "D" in the `scale` (C C# D D# E F F# G G# A A# B C), you
+  should return the following notes for the given `step`:
+
+  "m": D#
+  "M": E
+  "A": F
+  """
+  @spec step(scale :: list(String.t()), tonic :: String.t(), step :: String.t()) :: list(String.t())
+  def step(scale, tonic, step) do
+  end
+
+  @doc """
+  The chromatic scale is a musical scale with thirteen pitches, each a semitone
   (half-tone) above or below another.
 
   Notes with a sharp (#) are a semitone higher than the note below them, where
   the next letter note is a full tone except in the case of B and E, which have
   no sharps.
 
-  Generate these 12 notes, starting with the given `tonic` and wrapping back
-  around to the note before it. If the `tonic` is lowercase, capitalize it.
+  Generate these notes, starting with the given `tonic` and wrapping back
+  around to the note before it, ending with the tonic an octave higher than the
+  original. If the `tonic` is lowercase, capitalize it.
 
-  "C" should generate: ~w(C C# D D# E F F# G G# A A# B)
+  "C" should generate: ~w(C C# D D# E F F# G G# A A# B C)
   """
   @spec chromatic_scale(tonic :: String.t()) :: list(String.t())
   def chromatic_scale(tonic \\ "C") do
@@ -18,14 +37,15 @@ defmodule ScaleGenerator do
 
   @doc """
   Sharp notes can also be considered the flat (b) note of the tone above them,
-  so the 12 notes can also be represented as:
+  so the notes can also be represented as:
 
   A Bb B C Db D Eb E F Gb G Ab
 
-  Generate these 12 notes, starting with the given `tonic` and wrapping back
-  around to the note before it. If the `tonic` is lowercase, capitalize it.
+  Generate these notes, starting with the given `tonic` and wrapping back
+  around to the note before it, ending with the tonic an octave higher than the
+  original. If the `tonic` is lowercase, capitalize it.
 
-  "C" should generate: ~w(C Db D Eb E F Gb G Ab A Bb B)
+  "C" should generate: ~w(C Db D Eb E F Gb G Ab A Bb B C)
   """
   @spec flat_chromatic_scale(tonic :: String.t()) :: list(String.t())
   def flat_chromatic_scale(tonic \\ "C") do
@@ -43,17 +63,6 @@ defmodule ScaleGenerator do
   """
   @spec find_chromatic_scale(tonic :: String.t()) :: list(String.t())
   def find_chromatic_scale(tonic) do
-  end
-
-  @doc """
-  Find the note a given interval (`step`) in `scale` after the `tonic`.
-
-  "m": one semitone
-  "M": two semitones (full tone)
-  "A": augmented second (three semitones)
-  """
-  @spec step(scale :: list(String.t()), tonic :: String.t(), step :: String.t()) :: list(String.t())
-  def step(scale, tonic, step) do
   end
 
   @doc """

--- a/exercises/scale-generator/scale_generator.exs
+++ b/exercises/scale-generator/scale_generator.exs
@@ -1,6 +1,6 @@
 defmodule ScaleGenerator do
   @doc """
-  Find the note a given interval (`step`) in `scale` after the `tonic`.
+  Find the note for a given interval (`step`) in a `scale` after the `tonic`.
 
   "m": one semitone
   "M": two semitones (full tone)

--- a/exercises/scale-generator/scale_generator_test.exs
+++ b/exercises/scale-generator/scale_generator_test.exs
@@ -21,74 +21,256 @@ defmodule ScaleGeneratorTest do
   @pentatonic_scale_pattern      "MMAMA"
   @enigmatic_scale_pattern       "mAMMMmm"
 
-  #@tag :pending
-  test "C Major scale" do
-    assert ScaleGenerator.scale("C", @major_scale_pattern) == ~w(C D E F G A B)
+  describe "generate chromatic scale" do
+    #@tag :pending
+    test "starting with A" do
+      assert ScaleGenerator.chromatic_scale("A") == ~w(A A# B C C# D D# E F F# G G#)
+    end
+
+    @tag :pending
+    test "starting with C" do
+      assert ScaleGenerator.chromatic_scale("C") == ~w(C C# D D# E F F# G G# A A# B)
+    end
+
+    @tag :pending
+    test "starting with G" do
+      assert ScaleGenerator.chromatic_scale("G") == ~w(G G# A A# B C C# D D# E F F#)
+    end
+
+    @tag :pending
+    test "works with with lowercase notes" do
+      assert ScaleGenerator.chromatic_scale("f#") == ~w(F# G G# A A# B C C# D D# E F)
+    end
   end
 
-  @tag :pending
-  test "G Major scale" do
-    assert ScaleGenerator.scale("G", @major_scale_pattern) == ~w(G A B C D E F#)
+  describe "generate flat chromatic scale" do
+    @tag :pending
+    test "starting with A" do
+      assert ScaleGenerator.flat_chromatic_scale("A") == ~w(A Bb B C Db D Eb E F Gb G Ab)
+    end
+
+    @tag :pending
+    test "starting with C" do
+      assert ScaleGenerator.flat_chromatic_scale("C") == ~w(C Db D Eb E F Gb G Ab A Bb B)
+    end
+
+    @tag :pending
+    test "starting with G" do
+      assert ScaleGenerator.flat_chromatic_scale("G") == ~w(G Ab A Bb B C Db D Eb E F Gb)
+    end
+
+    @tag :pending
+    test "works with with lowercase notes" do
+      assert ScaleGenerator.flat_chromatic_scale("Gb") == ~w(Gb G Ab A Bb B C Db D Eb E F)
+    end
   end
 
-  @tag :pending
-  test "f# minor scale" do
-    assert ScaleGenerator.scale("f#", @minor_scale_pattern) == ~w(F# G# A B C# D E)
+  describe "find chromatic scale for flat tonics" do
+    @tag :pending
+    test "using F" do
+      assert ScaleGenerator.find_chromatic_scale("F") == ~w(F Gb G Ab A Bb B C Db D Eb E)
+    end
+
+    @tag :pending
+    test "using Bb" do
+      assert ScaleGenerator.find_chromatic_scale("Bb") == ~w(Bb B C Db D Eb E F Gb G Ab A)
+    end
+
+    @tag :pending
+    test "using Eb" do
+      assert ScaleGenerator.find_chromatic_scale("Eb") == ~w(Eb E F Gb G Ab A Bb B C Db D)
+    end
+
+    @tag :pending
+    test "using Ab" do
+      assert ScaleGenerator.find_chromatic_scale("Ab") == ~w(Ab A Bb B C Db D Eb E F Gb G)
+    end
+
+    @tag :pending
+    test "using Db" do
+      assert ScaleGenerator.find_chromatic_scale("Db") == ~w(Db D Eb E F Gb G Ab A Bb B C)
+    end
+
+    @tag :pending
+    test "using Gb" do
+      assert ScaleGenerator.find_chromatic_scale("Gb") == ~w(Gb G Ab A Bb B C Db D Eb E F)
+    end
+
+    @tag :pending
+    test "using d" do
+      assert ScaleGenerator.find_chromatic_scale("d") == ~w(D Eb E F Gb G Ab A Bb B C Db)
+    end
+
+    @tag :pending
+    test "using g" do
+      assert ScaleGenerator.find_chromatic_scale("g") == ~w(G Ab A Bb B C Db D Eb E F Gb )
+    end
+
+    @tag :pending
+    test "using c" do
+      assert ScaleGenerator.find_chromatic_scale("c") == ~w(C Db D Eb E F Gb G Ab A Bb B )
+    end
+
+    @tag :pending
+    test "using f" do
+      assert ScaleGenerator.find_chromatic_scale("f") == ~w(F Gb G Ab A Bb B C Db D Eb E)
+    end
+
+    @tag :pending
+    test "using bb" do
+      assert ScaleGenerator.find_chromatic_scale("bb") == ~w(Bb B C Db D Eb E F Gb G Ab A)
+    end
+
+    @tag :pending
+    test "using eb" do
+      assert ScaleGenerator.find_chromatic_scale("eb") == ~w(Eb E F Gb G Ab A Bb B C Db D)
+    end
   end
 
-  @tag :pending
-  test "b flat minor scale" do
-    assert ScaleGenerator.scale("bb", @minor_scale_pattern) == ~w(Bb C Db Eb F Gb Ab)
+  describe "find chromatic scale for non-flat tonics" do
+    @tag :pending
+    test "using A" do
+      assert ScaleGenerator.find_chromatic_scale("A") == ~w(A A# B C C# D D# E F F# G G#)
+    end
+
+    @tag :pending
+    test "using A#" do
+      assert ScaleGenerator.find_chromatic_scale("A#") == ~w(A# B C C# D D# E F F# G G# A)
+    end
+
+    @tag :pending
+    test "using B" do
+      assert ScaleGenerator.find_chromatic_scale("B") == ~w(B C C# D D# E F F# G G# A A#)
+    end
+
+    @tag :pending
+    test "using C" do
+      assert ScaleGenerator.find_chromatic_scale("C") == ~w(C C# D D# E F F# G G# A A# B)
+    end
+
+    @tag :pending
+    test "using C#" do
+      assert ScaleGenerator.find_chromatic_scale("C#") == ~w(C# D D# E F F# G G# A A# B C)
+    end
+
+    @tag :pending
+    test "using D" do
+      assert ScaleGenerator.find_chromatic_scale("D") == ~w(D D# E F F# G G# A A# B C C#)
+    end
+
+    @tag :pending
+    test "using D#" do
+      assert ScaleGenerator.find_chromatic_scale("D#") == ~w(D# E F F# G G# A A# B C C# D)
+    end
+
+    @tag :pending
+    test "using E" do
+      assert ScaleGenerator.find_chromatic_scale("E") == ~w(E F F# G G# A A# B C C# D D#)
+    end
+
+    @tag :pending
+    test "using F#" do
+      assert ScaleGenerator.find_chromatic_scale("F#") == ~w(F# G G# A A# B C C# D D# E F)
+    end
+
+    @tag :pending
+    test "using G" do
+      assert ScaleGenerator.find_chromatic_scale("G") == ~w(G G# A A# B C C# D D# E F F#)
+    end
+
+    @tag :pending
+    test "using G#" do
+      assert ScaleGenerator.find_chromatic_scale("G#") == ~w(G# A A# B C C# D D# E F F# G)
+    end
   end
 
-  @tag :pending
-  test "D Dorian scale" do
-    assert ScaleGenerator.scale("d", @dorian_scale_pattern) == ~w(D E F G A B C);
+  describe "step to next note" do
+    @tag :pending
+    test "with half-tone interval" do
+      assert ScaleGenerator.step(~w(C C# D D# E F F# G G# A A# B), "C", "m") == "C#"
+    end
+
+    @tag :pending
+    test "with full tone interval" do
+      assert ScaleGenerator.step(~w(C C# D D# E F F# G G# A A# B), "C", "M") == "D"
+    end
+
+    @tag :pending
+    test "with accidental interval" do
+      assert ScaleGenerator.step(~w(C C# D D# E F F# G G# A A# B), "C", "A") == "D#"
+    end
   end
 
-  @tag :pending
-  test "E flat Mixolydian scale" do
-    assert ScaleGenerator.scale("Eb", @mixolydian_scale_pattern) == ~w(Eb F G Ab Bb C Db);
-  end
+  describe "generate scale from tonic and pattern" do
+    @tag :pending
+    test "C Major scale" do
+      assert ScaleGenerator.scale("C", @major_scale_pattern) == ~w(C D E F G A B C)
+    end
 
-  @tag :pending
-  test "a Lydian scale" do
-    assert ScaleGenerator.scale("a", @lydian_scale_pattern) == ~w(A B C# D# E F# G#);
-  end
+    @tag :pending
+    test "G Major scale" do
+      assert ScaleGenerator.scale("G", @major_scale_pattern) == ~w(G A B C D E F# G)
+    end
 
-  @tag :pending
-  test "e Phrygian scale" do
-    assert ScaleGenerator.scale("e", @phrygian_scale_pattern) == ~w(E F G A B C D);
-  end
+    @tag :pending
+    test "f# minor scale" do
+      assert ScaleGenerator.scale("f#", @minor_scale_pattern) == ~w(F# G# A B C# D E F#)
+    end
 
-  @tag :pending
-  test "g Locrian scale" do
-    assert ScaleGenerator.scale("g", @locrian_scale_pattern) == ~w(G Ab Bb C Db Eb F);
-  end
+    @tag :pending
+    test "b flat minor scale" do
+      assert ScaleGenerator.scale("bb", @minor_scale_pattern) == ~w(Bb C Db Eb F Gb Ab Bb)
+    end
 
-  @tag :pending
-  test "d Harmonic minor scale" do
-    assert ScaleGenerator.scale("d", @harmonic_minor_scale_pattern) == ~w(D E F G A Bb Db);
-  end
+    @tag :pending
+    test "D Dorian scale" do
+      assert ScaleGenerator.scale("d", @dorian_scale_pattern) == ~w(D E F G A B C D)
+    end
 
-  @tag :pending
-  test "C Octatonic scale" do
-    assert ScaleGenerator.scale("C", @octatonic_scale_pattern) == ~w(C D D# F F# G# A B);
-  end
+    @tag :pending
+    test "E flat Mixolydian scale" do
+      assert ScaleGenerator.scale("Eb", @mixolydian_scale_pattern) == ~w(Eb F G Ab Bb C Db Eb)
+    end
 
-  @tag :pending
-  test "D flat Hexatonic scale" do
-    assert ScaleGenerator.scale("Db", @hexatonic_scale_pattern) == ~w(Db Eb F G A B);
-  end
+    @tag :pending
+    test "a Lydian scale" do
+      assert ScaleGenerator.scale("a", @lydian_scale_pattern) == ~w(A B C# D# E F# G# A)
+    end
 
-  @tag :pending
-  test "A Pentatonic scale" do
-    assert ScaleGenerator.scale("A", @pentatonic_scale_pattern) == ~w(A B C# E F#);
-  end
+    @tag :pending
+    test "e Phrygian scale" do
+      assert ScaleGenerator.scale("e", @phrygian_scale_pattern) == ~w(E F G A B C D E)
+    end
 
-  @tag :pending
-  test "G Enigmatic scale" do
-    assert ScaleGenerator.scale("G", @enigmatic_scale_pattern) == ~w(G G# B C# D# F F#);
+    @tag :pending
+    test "g Locrian scale" do
+      assert ScaleGenerator.scale("g", @locrian_scale_pattern) == ~w(G Ab Bb C Db Eb F G)
+    end
+
+    @tag :pending
+    test "d Harmonic minor scale" do
+      assert ScaleGenerator.scale("d", @harmonic_minor_scale_pattern) == ~w(D E F G A Bb Db D)
+    end
+
+    @tag :pending
+    test "C Octatonic scale" do
+      assert ScaleGenerator.scale("C", @octatonic_scale_pattern) == ~w(C D D# F F# G# A B C)
+    end
+
+    @tag :pending
+    test "D flat Hexatonic scale" do
+      assert ScaleGenerator.scale("Db", @hexatonic_scale_pattern) == ~w(Db Eb F G A B Db)
+    end
+
+    @tag :pending
+    test "A Pentatonic scale" do
+      assert ScaleGenerator.scale("A", @pentatonic_scale_pattern) == ~w(A B C# E F# A)
+    end
+
+    @tag :pending
+    test "G Enigmatic scale" do
+      assert ScaleGenerator.scale("G", @enigmatic_scale_pattern) == ~w(G G# B C# D# F F# G)
+    end
   end
 end
 

--- a/exercises/scale-generator/scale_generator_test.exs
+++ b/exercises/scale-generator/scale_generator_test.exs
@@ -42,163 +42,163 @@ defmodule ScaleGeneratorTest do
   describe "generate chromatic scale" do
     @tag :pending
     test "starting with A" do
-      assert ScaleGenerator.chromatic_scale("A") == ~w(A A# B C C# D D# E F F# G G#)
+      assert ScaleGenerator.chromatic_scale("A") == ~w(A A# B C C# D D# E F F# G G# A)
     end
 
     @tag :pending
     test "starting with C" do
-      assert ScaleGenerator.chromatic_scale("C") == ~w(C C# D D# E F F# G G# A A# B)
+      assert ScaleGenerator.chromatic_scale("C") == ~w(C C# D D# E F F# G G# A A# B C)
     end
 
     @tag :pending
     test "starting with G" do
-      assert ScaleGenerator.chromatic_scale("G") == ~w(G G# A A# B C C# D D# E F F#)
+      assert ScaleGenerator.chromatic_scale("G") == ~w(G G# A A# B C C# D D# E F F# G)
     end
 
     @tag :pending
     test "works with with lowercase notes" do
-      assert ScaleGenerator.chromatic_scale("f#") == ~w(F# G G# A A# B C C# D D# E F)
+      assert ScaleGenerator.chromatic_scale("f#") == ~w(F# G G# A A# B C C# D D# E F F#)
     end
   end
 
   describe "generate flat chromatic scale" do
     @tag :pending
     test "starting with A" do
-      assert ScaleGenerator.flat_chromatic_scale("A") == ~w(A Bb B C Db D Eb E F Gb G Ab)
+      assert ScaleGenerator.flat_chromatic_scale("A") == ~w(A Bb B C Db D Eb E F Gb G Ab A)
     end
 
     @tag :pending
     test "starting with C" do
-      assert ScaleGenerator.flat_chromatic_scale("C") == ~w(C Db D Eb E F Gb G Ab A Bb B)
+      assert ScaleGenerator.flat_chromatic_scale("C") == ~w(C Db D Eb E F Gb G Ab A Bb B C)
     end
 
     @tag :pending
     test "starting with G" do
-      assert ScaleGenerator.flat_chromatic_scale("G") == ~w(G Ab A Bb B C Db D Eb E F Gb)
+      assert ScaleGenerator.flat_chromatic_scale("G") == ~w(G Ab A Bb B C Db D Eb E F Gb G)
     end
 
     @tag :pending
     test "works with with lowercase notes" do
-      assert ScaleGenerator.flat_chromatic_scale("Gb") == ~w(Gb G Ab A Bb B C Db D Eb E F)
+      assert ScaleGenerator.flat_chromatic_scale("Gb") == ~w(Gb G Ab A Bb B C Db D Eb E F Gb)
     end
   end
 
   describe "find chromatic scale for flat tonics" do
     @tag :pending
     test "using F" do
-      assert ScaleGenerator.find_chromatic_scale("F") == ~w(F Gb G Ab A Bb B C Db D Eb E)
+      assert ScaleGenerator.find_chromatic_scale("F") == ~w(F Gb G Ab A Bb B C Db D Eb E F)
     end
 
     @tag :pending
     test "using Bb" do
-      assert ScaleGenerator.find_chromatic_scale("Bb") == ~w(Bb B C Db D Eb E F Gb G Ab A)
+      assert ScaleGenerator.find_chromatic_scale("Bb") == ~w(Bb B C Db D Eb E F Gb G Ab A Bb)
     end
 
     @tag :pending
     test "using Eb" do
-      assert ScaleGenerator.find_chromatic_scale("Eb") == ~w(Eb E F Gb G Ab A Bb B C Db D)
+      assert ScaleGenerator.find_chromatic_scale("Eb") == ~w(Eb E F Gb G Ab A Bb B C Db D Eb)
     end
 
     @tag :pending
     test "using Ab" do
-      assert ScaleGenerator.find_chromatic_scale("Ab") == ~w(Ab A Bb B C Db D Eb E F Gb G)
+      assert ScaleGenerator.find_chromatic_scale("Ab") == ~w(Ab A Bb B C Db D Eb E F Gb G Ab)
     end
 
     @tag :pending
     test "using Db" do
-      assert ScaleGenerator.find_chromatic_scale("Db") == ~w(Db D Eb E F Gb G Ab A Bb B C)
+      assert ScaleGenerator.find_chromatic_scale("Db") == ~w(Db D Eb E F Gb G Ab A Bb B C Db)
     end
 
     @tag :pending
     test "using Gb" do
-      assert ScaleGenerator.find_chromatic_scale("Gb") == ~w(Gb G Ab A Bb B C Db D Eb E F)
+      assert ScaleGenerator.find_chromatic_scale("Gb") == ~w(Gb G Ab A Bb B C Db D Eb E F Gb)
     end
 
     @tag :pending
     test "using d" do
-      assert ScaleGenerator.find_chromatic_scale("d") == ~w(D Eb E F Gb G Ab A Bb B C Db)
+      assert ScaleGenerator.find_chromatic_scale("d") == ~w(D Eb E F Gb G Ab A Bb B C Db D)
     end
 
     @tag :pending
     test "using g" do
-      assert ScaleGenerator.find_chromatic_scale("g") == ~w(G Ab A Bb B C Db D Eb E F Gb )
+      assert ScaleGenerator.find_chromatic_scale("g") == ~w(G Ab A Bb B C Db D Eb E F Gb  G)
     end
 
     @tag :pending
     test "using c" do
-      assert ScaleGenerator.find_chromatic_scale("c") == ~w(C Db D Eb E F Gb G Ab A Bb B )
+      assert ScaleGenerator.find_chromatic_scale("c") == ~w(C Db D Eb E F Gb G Ab A Bb B  C)
     end
 
     @tag :pending
     test "using f" do
-      assert ScaleGenerator.find_chromatic_scale("f") == ~w(F Gb G Ab A Bb B C Db D Eb E)
+      assert ScaleGenerator.find_chromatic_scale("f") == ~w(F Gb G Ab A Bb B C Db D Eb E F)
     end
 
     @tag :pending
     test "using bb" do
-      assert ScaleGenerator.find_chromatic_scale("bb") == ~w(Bb B C Db D Eb E F Gb G Ab A)
+      assert ScaleGenerator.find_chromatic_scale("bb") == ~w(Bb B C Db D Eb E F Gb G Ab A Bb)
     end
 
     @tag :pending
     test "using eb" do
-      assert ScaleGenerator.find_chromatic_scale("eb") == ~w(Eb E F Gb G Ab A Bb B C Db D)
+      assert ScaleGenerator.find_chromatic_scale("eb") == ~w(Eb E F Gb G Ab A Bb B C Db D Eb)
     end
   end
 
   describe "find chromatic scale for non-flat tonics" do
     @tag :pending
     test "using A" do
-      assert ScaleGenerator.find_chromatic_scale("A") == ~w(A A# B C C# D D# E F F# G G#)
+      assert ScaleGenerator.find_chromatic_scale("A") == ~w(A A# B C C# D D# E F F# G G# A)
     end
 
     @tag :pending
     test "using A#" do
-      assert ScaleGenerator.find_chromatic_scale("A#") == ~w(A# B C C# D D# E F F# G G# A)
+      assert ScaleGenerator.find_chromatic_scale("A#") == ~w(A# B C C# D D# E F F# G G# A A#)
     end
 
     @tag :pending
     test "using B" do
-      assert ScaleGenerator.find_chromatic_scale("B") == ~w(B C C# D D# E F F# G G# A A#)
+      assert ScaleGenerator.find_chromatic_scale("B") == ~w(B C C# D D# E F F# G G# A A# B)
     end
 
     @tag :pending
     test "using C" do
-      assert ScaleGenerator.find_chromatic_scale("C") == ~w(C C# D D# E F F# G G# A A# B)
+      assert ScaleGenerator.find_chromatic_scale("C") == ~w(C C# D D# E F F# G G# A A# B C)
     end
 
     @tag :pending
     test "using C#" do
-      assert ScaleGenerator.find_chromatic_scale("C#") == ~w(C# D D# E F F# G G# A A# B C)
+      assert ScaleGenerator.find_chromatic_scale("C#") == ~w(C# D D# E F F# G G# A A# B C C#)
     end
 
     @tag :pending
     test "using D" do
-      assert ScaleGenerator.find_chromatic_scale("D") == ~w(D D# E F F# G G# A A# B C C#)
+      assert ScaleGenerator.find_chromatic_scale("D") == ~w(D D# E F F# G G# A A# B C C# D)
     end
 
     @tag :pending
     test "using D#" do
-      assert ScaleGenerator.find_chromatic_scale("D#") == ~w(D# E F F# G G# A A# B C C# D)
+      assert ScaleGenerator.find_chromatic_scale("D#") == ~w(D# E F F# G G# A A# B C C# D D#)
     end
 
     @tag :pending
     test "using E" do
-      assert ScaleGenerator.find_chromatic_scale("E") == ~w(E F F# G G# A A# B C C# D D#)
+      assert ScaleGenerator.find_chromatic_scale("E") == ~w(E F F# G G# A A# B C C# D D# E)
     end
 
     @tag :pending
     test "using F#" do
-      assert ScaleGenerator.find_chromatic_scale("F#") == ~w(F# G G# A A# B C C# D D# E F)
+      assert ScaleGenerator.find_chromatic_scale("F#") == ~w(F# G G# A A# B C C# D D# E F F#)
     end
 
     @tag :pending
     test "using G" do
-      assert ScaleGenerator.find_chromatic_scale("G") == ~w(G G# A A# B C C# D D# E F F#)
+      assert ScaleGenerator.find_chromatic_scale("G") == ~w(G G# A A# B C C# D D# E F F# G)
     end
 
     @tag :pending
     test "using G#" do
-      assert ScaleGenerator.find_chromatic_scale("G#") == ~w(G# A A# B C C# D D# E F F# G)
+      assert ScaleGenerator.find_chromatic_scale("G#") == ~w(G# A A# B C C# D D# E F F# G G#)
     end
   end
 

--- a/exercises/scale-generator/scale_generator_test.exs
+++ b/exercises/scale-generator/scale_generator_test.exs
@@ -3,7 +3,7 @@ if !System.get_env("EXERCISM_TEST_EXAMPLES") do
 end
 
 ExUnit.start
-ExUnit.configure exclude: :pending, trace: true
+ExUnit.configure trace: true, exclude: :pending
 
 defmodule ScaleGeneratorTest do
   use ExUnit.Case
@@ -16,13 +16,31 @@ defmodule ScaleGeneratorTest do
   @phrygian_scale_pattern        "mMMMmMM"
   @locrian_scale_pattern         "mMMmMMM"
   @harmonic_minor_scale_pattern  "MmMMmAm"
+  @melodic_minor_scale_pattern   "MmMMMMm"
   @octatonic_scale_pattern       "MmMmMmMm"
   @hexatonic_scale_pattern       "MMMMMM"
   @pentatonic_scale_pattern      "MMAMA"
   @enigmatic_scale_pattern       "mAMMMmm"
 
-  describe "generate chromatic scale" do
+  describe "step to next note" do
     #@tag :pending
+    test "with half-tone interval" do
+      assert ScaleGenerator.step(~w(C C# D D# E F F# G G# A A# B), "C", "m") == "C#"
+    end
+
+    @tag :pending
+    test "with full tone interval" do
+      assert ScaleGenerator.step(~w(C C# D D# E F F# G G# A A# B), "C", "M") == "D"
+    end
+
+    @tag :pending
+    test "with accidental interval" do
+      assert ScaleGenerator.step(~w(C C# D D# E F F# G G# A A# B), "C", "A") == "D#"
+    end
+  end
+
+  describe "generate chromatic scale" do
+    @tag :pending
     test "starting with A" do
       assert ScaleGenerator.chromatic_scale("A") == ~w(A A# B C C# D D# E F F# G G#)
     end
@@ -184,23 +202,6 @@ defmodule ScaleGeneratorTest do
     end
   end
 
-  describe "step to next note" do
-    @tag :pending
-    test "with half-tone interval" do
-      assert ScaleGenerator.step(~w(C C# D D# E F F# G G# A A# B), "C", "m") == "C#"
-    end
-
-    @tag :pending
-    test "with full tone interval" do
-      assert ScaleGenerator.step(~w(C C# D D# E F F# G G# A A# B), "C", "M") == "D"
-    end
-
-    @tag :pending
-    test "with accidental interval" do
-      assert ScaleGenerator.step(~w(C C# D D# E F F# G G# A A# B), "C", "A") == "D#"
-    end
-  end
-
   describe "generate scale from tonic and pattern" do
     @tag :pending
     test "C Major scale" do
@@ -250,6 +251,11 @@ defmodule ScaleGeneratorTest do
     @tag :pending
     test "d Harmonic minor scale" do
       assert ScaleGenerator.scale("d", @harmonic_minor_scale_pattern) == ~w(D E F G A Bb Db D)
+    end
+
+    @tag :pending
+    test "C Melodic minor scale" do
+      assert ScaleGenerator.scale("C", @melodic_minor_scale_pattern) == ~w(C D D# F G A B C)
     end
 
     @tag :pending

--- a/exercises/scale-generator/scale_generator_test.exs
+++ b/exercises/scale-generator/scale_generator_test.exs
@@ -1,0 +1,94 @@
+if !System.get_env("EXERCISM_TEST_EXAMPLES") do
+  Code.load_file("scale_generator.exs", __DIR__)
+end
+
+ExUnit.start
+ExUnit.configure exclude: :pending, trace: true
+
+defmodule ScaleGeneratorTest do
+  use ExUnit.Case
+
+  @major_scale_pattern           "MMmMMMm"
+  @minor_scale_pattern           "MmMMmMM"
+  @dorian_scale_pattern          "MmMMMmM"
+  @mixolydian_scale_pattern      "MMmMMmM"
+  @lydian_scale_pattern          "MMMmMMm"
+  @phrygian_scale_pattern        "mMMMmMM"
+  @locrian_scale_pattern         "mMMmMMM"
+  @harmonic_minor_scale_pattern  "MmMMmAm"
+  @octatonic_scale_pattern       "MmMmMmMm"
+  @hexatonic_scale_pattern       "MMMMMM"
+  @pentatonic_scale_pattern      "MMAMA"
+  @enigmatic_scale_pattern       "mAMMMmm"
+
+  #@tag :pending
+  test "C Major scale" do
+    assert ScaleGenerator.scale("C", @major_scale_pattern) == ~w(C D E F G A B)
+  end
+
+  @tag :pending
+  test "G Major scale" do
+    assert ScaleGenerator.scale("G", @major_scale_pattern) == ~w(G A B C D E F#)
+  end
+
+  @tag :pending
+  test "f# minor scale" do
+    assert ScaleGenerator.scale("f#", @minor_scale_pattern) == ~w(F# G# A B C# D E)
+  end
+
+  @tag :pending
+  test "b flat minor scale" do
+    assert ScaleGenerator.scale("bb", @minor_scale_pattern) == ~w(Bb C Db Eb F Gb Ab)
+  end
+
+  @tag :pending
+  test "D Dorian scale" do
+    assert ScaleGenerator.scale("d", @dorian_scale_pattern) == ~w(D E F G A B C);
+  end
+
+  @tag :pending
+  test "E flat Mixolydian scale" do
+    assert ScaleGenerator.scale("Eb", @mixolydian_scale_pattern) == ~w(Eb F G Ab Bb C Db);
+  end
+
+  @tag :pending
+  test "a Lydian scale" do
+    assert ScaleGenerator.scale("a", @lydian_scale_pattern) == ~w(A B C# D# E F# G#);
+  end
+
+  @tag :pending
+  test "e Phrygian scale" do
+    assert ScaleGenerator.scale("e", @phrygian_scale_pattern) == ~w(E F G A B C D);
+  end
+
+  @tag :pending
+  test "g Locrian scale" do
+    assert ScaleGenerator.scale("g", @locrian_scale_pattern) == ~w(G Ab Bb C Db Eb F);
+  end
+
+  @tag :pending
+  test "d Harmonic minor scale" do
+    assert ScaleGenerator.scale("d", @harmonic_minor_scale_pattern) == ~w(D E F G A Bb Db);
+  end
+
+  @tag :pending
+  test "C Octatonic scale" do
+    assert ScaleGenerator.scale("C", @octatonic_scale_pattern) == ~w(C D D# F F# G# A B);
+  end
+
+  @tag :pending
+  test "D flat Hexatonic scale" do
+    assert ScaleGenerator.scale("Db", @hexatonic_scale_pattern) == ~w(Db Eb F G A B);
+  end
+
+  @tag :pending
+  test "A Pentatonic scale" do
+    assert ScaleGenerator.scale("A", @pentatonic_scale_pattern) == ~w(A B C# E F#);
+  end
+
+  @tag :pending
+  test "G Enigmatic scale" do
+    assert ScaleGenerator.scale("G", @enigmatic_scale_pattern) == ~w(G G# B C# D# F F#);
+  end
+end
+


### PR DESCRIPTION
The common documentation doesn't tell you much, and there are no canonical exercises, so these are entirely based off the C# and Ruby versions, which for some reason that's not explained in the docs drop the last note, so if you're doing an `Enum.map` over the major scale pattern, you'd expect the first example to give

`["C", "D", "E", "F", "G", "A", "B", "C"]`

But the other implementations drop the final `"C"`, so to match them, I did as well.

I gave this a 5 for difficulty, but feel free to suggest higher or lower as you feel appropriate.