### PR TITLE
Add test to bank-account to ensure `close_account/1` is implemented.

### DIFF
--- a/exercises/bank-account/bank_account_test.exs
+++ b/exercises/bank-account/bank_account_test.exs
@@ -51,6 +51,14 @@ defmodule BankAccountTest do
   end
 
   @tag :pending
+  test "closing account rejects further inquiries", %{account: account} do
+    assert BankAccount.balance(account) == 0
+    BankAccount.close_bank(account)
+    assert BankAccount.balance(account) == {:error, :account_closed}
+    assert BankAccount.update(account, 10) == {:error, :account_closed}
+  end
+
+  @tag :pending
   test "incrementing balance from another process then checking it from test process", %{account: account} do
     assert BankAccount.balance(account) == 0
     this = self()

--- a/exercises/bank-account/example.exs
+++ b/exercises/bank-account/example.exs
@@ -53,13 +53,21 @@ defmodule BankAccount do
   """
   @spec balance(account) :: integer
   def balance(account) do
-    :gen_server.call(account, :balance)
+    if Process.alive?(account) do
+      :gen_server.call(account, :balance)
+    else
+      { :error, :account_closed }
+    end
   end
 
   @doc """
   Update the account's balance by adding the given amount which may be negative.
   """
   def update(account, amount) do
-    :gen_server.call(account, { :update, amount })
+    if Process.alive?(account) do
+      :gen_server.call(account, { :update, amount })
+    else
+      { :error, :account_closed }
+    end
   end
 end


### PR DESCRIPTION
This test specifically asks for the implementation to return a tuple,
`{:error, :account_closed}`. I figured that it's probably best because
it feels nicer than just asserting that an error is raised. If that's
preferable, though, feel free to change this.

Closes #319 