### PR TITLE
Implement Tournament exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -221,6 +221,15 @@
       ]
     },
     {
+      "slug": "tournament",
+      "difficulty": 4,
+      "topics": [
+        "string processing",
+        "sorting",
+        "formatting"
+      ]
+    },
+    {
       "slug": "list-ops",
       "difficulty": 4,
       "topics": [

--- a/exercises/tournament/HINTS.md
+++ b/exercises/tournament/HINTS.md
@@ -1,0 +1,3 @@
+Formatting the output is easy with `String`'s padding functions. All number
+columns can be left-padded with spaces to a width of 2 characters, while the
+team name column can be right-padded with spaces to a width of 30.

--- a/exercises/tournament/example.exs
+++ b/exercises/tournament/example.exs
@@ -1,0 +1,81 @@
+defmodule Tournament do
+  @stats_header { "Team", "MP", "W", "D", "L", "P" }
+  @initial_stats { 0, 0, 0, 0, 0 }
+
+  @doc """
+  Given `input` lines representing two teams and whether the first of them won,
+  lost, or reached a draw, separated by semicolons, calculate the statistics
+  for each team's number of games played, won, drawn, lost, and total points
+  for the season, and return a nicely-formatted string table.
+
+  A win earns a team 3 points, a draw earns 1 point, and a loss earns nothing.
+
+  Order the outcome by most total points for the season, and settle ties by
+  listing the teams in alphabetical order.
+  """
+  @spec tally(input :: list(String.t())) :: String.t()
+  def tally(input) do
+    %{}
+    |> do_tally(input)
+    |> Enum.into([], fn {k, v} -> Tuple.insert_at(v, 0, k) end)
+    |> Enum.sort(&sort_results/2)
+    |> List.insert_at(0, @stats_header)
+    |> Enum.map_join("\n", &format_results/1)
+  end
+
+  defp do_tally(results, []), do: results
+  defp do_tally(results, [line | rest]) do
+    results
+    |> parse_line(line |> String.split(";", trim: true))
+    |> do_tally(rest)
+  end
+
+  defp parse_line(results, [first, second, "win"]) do
+    results |> mark_win(first) |> mark_loss(second)
+  end
+
+  defp parse_line(results, [first, second, "draw"]) do
+    results |> mark_draw(first) |> mark_draw(second)
+  end
+
+  defp parse_line(results, [first, second, "loss"]) do
+    results |> mark_loss(first) |> mark_win(second)
+  end
+
+  defp parse_line(results, _), do: results
+
+  defp mark_win(results, team) do
+    { played, wins, draws, lost, points } = Map.get(results, team, @initial_stats)
+
+    Map.put(results, team, { played + 1, wins + 1, draws, lost, points + 3 })
+  end
+
+  defp mark_draw(results, team) do
+    { played, wins, draws, lost, points } = Map.get(results, team, @initial_stats)
+
+    Map.put(results, team, { played + 1, wins, draws + 1, lost, points + 1})
+  end
+
+  defp mark_loss(results, team) do
+    { played, wins, draws, lost, points } = Map.get(results, team, @initial_stats)
+
+    Map.put(results, team, { played + 1, wins, draws, lost + 1, points})
+  end
+
+  defp sort_results({_, _, _, _, _, points_a}, {_, _, _, _, _, points_b}) when points_a > points_b, do: true
+  defp sort_results({_, _, _, _, _, points_a}, {_, _, _, _, _, points_b}) when points_a < points_b, do: false
+  defp sort_results({name_a, _, _, _, _, _}, {name_b, _, _, _, _, _}) when name_a <= name_b, do: true
+  defp sort_results(_, _), do: false
+
+  defp format_results({name, played, wins, draws, lost, points}) do
+    [
+      name |> String.pad_trailing(30),
+      played |> to_string |> String.pad_leading(2),
+      wins |> to_string |> String.pad_leading(2),
+      draws |> to_string |> String.pad_leading(2),
+      lost |> to_string |> String.pad_leading(2),
+      points |> to_string |> String.pad_leading(2)
+    ] |> Enum.join(" | ")
+  end
+end
+

--- a/exercises/tournament/tournament.exs
+++ b/exercises/tournament/tournament.exs
@@ -1,0 +1,17 @@
+defmodule Tournament do
+  @doc """
+  Given `input` lines representing two teams and whether the first of them won,
+  lost, or reached a draw, separated by semicolons, calculate the statistics
+  for each team's number of games played, won, drawn, lost, and total points
+  for the season, and return a nicely-formatted string table.
+
+  A win earns a team 3 points, a draw earns 1 point, and a loss earns nothing.
+
+  Order the outcome by most total points for the season, and settle ties by
+  listing the teams in alphabetical order.
+  """
+  @spec tally(input :: list(String.t())) :: String.t()
+  def tally(input) do
+  end
+end
+

--- a/exercises/tournament/tournament_test.exs
+++ b/exercises/tournament/tournament_test.exs
@@ -1,0 +1,96 @@
+if !System.get_env("EXERCISM_TEST_EXAMPLES") do
+  Code.load_file("tournament.exs", __DIR__)
+end
+
+ExUnit.start
+ExUnit.configure trace: true, exclude: :pending
+
+defmodule TournamentTest do
+  use ExUnit.Case
+
+  #@tag :pending
+  test "typical input" do
+    input = [
+      "Allegoric Alaskans;Blithering Badgers;win",
+      "Devastating Donkeys;Courageous Californians;draw",
+      "Devastating Donkeys;Allegoric Alaskans;win",
+      "Courageous Californians;Blithering Badgers;loss",
+      "Blithering Badgers;Devastating Donkeys;loss",
+      "Allegoric Alaskans;Courageous Californians;win"
+    ]
+
+    expected = """
+    Team                           | MP |  W |  D |  L |  P
+    Devastating Donkeys            |  3 |  2 |  1 |  0 |  7
+    Allegoric Alaskans             |  3 |  2 |  0 |  1 |  6
+    Blithering Badgers             |  3 |  1 |  0 |  2 |  3
+    Courageous Californians        |  3 |  0 |  1 |  2 |  1
+    """ |> String.trim
+
+    assert Tournament.tally(input) == expected
+  end
+
+  @tag :pending
+  test "incomplete competition (not all pairs have played)" do
+    input = [
+      "Allegoric Alaskans;Blithering Badgers;loss",
+      "Devastating Donkeys;Allegoric Alaskans;loss",
+      "Courageous Californians;Blithering Badgers;draw",
+      "Allegoric Alaskans;Courageous Californians;win"
+    ]
+
+    expected = """
+    Team                           | MP |  W |  D |  L |  P
+    Allegoric Alaskans             |  3 |  2 |  0 |  1 |  6
+    Blithering Badgers             |  2 |  1 |  1 |  0 |  4
+    Courageous Californians        |  2 |  0 |  1 |  1 |  1
+    Devastating Donkeys            |  1 |  0 |  0 |  1 |  0
+    """ |> String.trim
+
+    assert Tournament.tally(input) == expected
+  end
+
+  @tag :pending
+  test "ties broken alphabetically" do
+    input = [
+      "Courageous Californians;Devastating Donkeys;win",
+      "Allegoric Alaskans;Blithering Badgers;win",
+      "Devastating Donkeys;Allegoric Alaskans;loss",
+      "Courageous Californians;Blithering Badgers;win",
+      "Blithering Badgers;Devastating Donkeys;draw",
+      "Allegoric Alaskans;Courageous Californians;draw"
+    ]
+
+    expected = """
+    Team                           | MP |  W |  D |  L |  P
+    Allegoric Alaskans             |  3 |  2 |  1 |  0 |  7
+    Courageous Californians        |  3 |  2 |  1 |  0 |  7
+    Blithering Badgers             |  3 |  0 |  1 |  2 |  1
+    Devastating Donkeys            |  3 |  0 |  1 |  2 |  1
+    """ |> String.trim
+
+    assert Tournament.tally(input) == expected
+  end
+
+  @tag :pending
+  test "mostly invalid lines" do
+    # Invalid input lines in an otherwise-valid game still results in valid
+    # output.
+    input = [
+      "",
+      "Allegoric Alaskans@Blithering Badgers;draw",
+      "Blithering Badgers;Devastating Donkeys;loss",
+      "Devastating Donkeys;Courageous Californians;win;5",
+      "Courageous Californians;Allegoric Alaskans;los"
+    ]
+
+    expected = """
+    Team                           | MP |  W |  D |  L |  P
+    Devastating Donkeys            |  1 |  1 |  0 |  0 |  3
+    Blithering Badgers             |  1 |  0 |  0 |  1 |  0
+    """ |> String.trim
+
+    assert Tournament.tally(input) == expected
+  end
+end
+


### PR DESCRIPTION
This one kinda goes 0-60 like one of my earlier ones, but I'm basing it off the canonical examples. 

I've chosen to implement the example with a string => 5-tuple map, but it could've been done using `defstruct` as well. I just didn't want to force the user to use a particular implementation.

I think it would be a good way to teach structs, and can change it if necessary. Just let me know if you'd prefer it that way.