### PR TITLE
Implement Matrix exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -155,6 +155,14 @@
       ]
     },
     {
+      "slug": "matrix",
+      "difficulty": 3,
+      "topics": [
+        "structs",
+        "string processing"
+      ]
+    },
+    {
       "slug": "bracket-push",
       "difficulty": 3,
       "topics": [

--- a/exercises/matrix/example.exs
+++ b/exercises/matrix/example.exs
@@ -1,17 +1,17 @@
-defmodule Matrix do
+defmodule MatrixStruct do
   defstruct matrix: nil, transposed_matrix: nil
 
   @doc """
   Convert an `input` string, with rows separated by newlines and values
-  separated by single spaces, into a `Matrix` struct.
+  separated by single spaces, into a `MatrixStruct` struct.
   """
-  @spec from_string(input :: String.t()) :: %Matrix{}
+  @spec from_string(input :: String.t()) :: %MatrixStruct{}
   def from_string(input) do
     rows = input
            |> String.split("\n", trim: true)
            |> Enum.map(&parse_line/1)
 
-    %Matrix{
+    %MatrixStruct{
       matrix: rows,
       transposed_matrix: rows |> List.zip |> Enum.map(&Tuple.to_list/1)
     }
@@ -27,8 +27,8 @@ defmodule Matrix do
   Write the `matrix` out as a string, with rows separated by newlines and
   values separated by single spaces.
   """
-  @spec to_string(matrix :: %Matrix{}) :: String.t()
-  def to_string(%Matrix{ matrix: rows }) do
+  @spec to_string(matrix :: %MatrixStruct{}) :: String.t()
+  def to_string(%MatrixStruct{ matrix: rows }) do
     rows
     |> Enum.map(&join_row/1)
     |> Enum.join("\n")
@@ -39,25 +39,25 @@ defmodule Matrix do
   @doc """
   Given a `matrix`, return its rows as a list of lists of integers.
   """
-  @spec rows(matrix :: %Matrix{}) :: list(list(integer))
-  def rows(%Matrix{matrix: rows}), do: rows
+  @spec rows(matrix :: %MatrixStruct{}) :: list(list(integer))
+  def rows(%MatrixStruct{matrix: rows}), do: rows
 
   @doc """
   Given a `matrix` and `index`, return the row at `index`.
   """
-  @spec row(matrix :: %Matrix{}, index :: integer) :: list(integer)
-  def row(%Matrix{matrix: rows}, index), do: Enum.at(rows, index)
+  @spec row(matrix :: %MatrixStruct{}, index :: integer) :: list(integer)
+  def row(%MatrixStruct{matrix: rows}, index), do: Enum.at(rows, index)
 
   @doc """
   Given a `matrix`, return its columns as a list of lists of integers.
   """
-  @spec columns(matrix :: %Matrix{}) :: list(list(integer))
-  def columns(%Matrix{transposed_matrix: cols}), do: cols
+  @spec columns(matrix :: %MatrixStruct{}) :: list(list(integer))
+  def columns(%MatrixStruct{transposed_matrix: cols}), do: cols
 
   @doc """
   Given a `matrix` and `index`, return the column at `index`.
   """
-  @spec column(matrix :: %Matrix{}, index :: integer) :: list(integer)
-  def column(%Matrix{transposed_matrix: cols}, index), do: Enum.at(cols, index)
+  @spec column(matrix :: %MatrixStruct{}, index :: integer) :: list(integer)
+  def column(%MatrixStruct{transposed_matrix: cols}, index), do: Enum.at(cols, index)
 end
 

--- a/exercises/matrix/example.exs
+++ b/exercises/matrix/example.exs
@@ -1,17 +1,17 @@
-defmodule MatrixStruct do
+defmodule Matrix do
   defstruct matrix: nil, transposed_matrix: nil
 
   @doc """
   Convert an `input` string, with rows separated by newlines and values
-  separated by single spaces, into a `MatrixStruct` struct.
+  separated by single spaces, into a `Matrix` struct.
   """
-  @spec from_string(input :: String.t()) :: %MatrixStruct{}
+  @spec from_string(input :: String.t()) :: %Matrix{}
   def from_string(input) do
     rows = input
            |> String.split("\n", trim: true)
            |> Enum.map(&parse_line/1)
 
-    %MatrixStruct{
+    %Matrix{
       matrix: rows,
       transposed_matrix: rows |> List.zip |> Enum.map(&Tuple.to_list/1)
     }
@@ -27,8 +27,8 @@ defmodule MatrixStruct do
   Write the `matrix` out as a string, with rows separated by newlines and
   values separated by single spaces.
   """
-  @spec to_string(matrix :: %MatrixStruct{}) :: String.t()
-  def to_string(%MatrixStruct{ matrix: rows }) do
+  @spec to_string(matrix :: %Matrix{}) :: String.t()
+  def to_string(%Matrix{ matrix: rows }) do
     rows
     |> Enum.map(&join_row/1)
     |> Enum.join("\n")
@@ -39,25 +39,25 @@ defmodule MatrixStruct do
   @doc """
   Given a `matrix`, return its rows as a list of lists of integers.
   """
-  @spec rows(matrix :: %MatrixStruct{}) :: list(list(integer))
-  def rows(%MatrixStruct{matrix: rows}), do: rows
+  @spec rows(matrix :: %Matrix{}) :: list(list(integer))
+  def rows(%Matrix{matrix: rows}), do: rows
 
   @doc """
   Given a `matrix` and `index`, return the row at `index`.
   """
-  @spec row(matrix :: %MatrixStruct{}, index :: integer) :: list(integer)
-  def row(%MatrixStruct{matrix: rows}, index), do: Enum.at(rows, index)
+  @spec row(matrix :: %Matrix{}, index :: integer) :: list(integer)
+  def row(%Matrix{matrix: rows}, index), do: Enum.at(rows, index)
 
   @doc """
   Given a `matrix`, return its columns as a list of lists of integers.
   """
-  @spec columns(matrix :: %MatrixStruct{}) :: list(list(integer))
-  def columns(%MatrixStruct{transposed_matrix: cols}), do: cols
+  @spec columns(matrix :: %Matrix{}) :: list(list(integer))
+  def columns(%Matrix{transposed_matrix: cols}), do: cols
 
   @doc """
   Given a `matrix` and `index`, return the column at `index`.
   """
-  @spec column(matrix :: %MatrixStruct{}, index :: integer) :: list(integer)
-  def column(%MatrixStruct{transposed_matrix: cols}, index), do: Enum.at(cols, index)
+  @spec column(matrix :: %Matrix{}, index :: integer) :: list(integer)
+  def column(%Matrix{transposed_matrix: cols}, index), do: Enum.at(cols, index)
 end
 

--- a/exercises/matrix/example.exs
+++ b/exercises/matrix/example.exs
@@ -1,0 +1,63 @@
+defmodule Matrix do
+  defstruct matrix: nil, transposed_matrix: nil
+
+  @doc """
+  Convert an `input` string, with rows separated by newlines and values
+  separated by single spaces, into a `Matrix` struct.
+  """
+  @spec from_string(input :: String.t()) :: %Matrix{}
+  def from_string(input) do
+    rows = input
+           |> String.split("\n", trim: true)
+           |> Enum.map(&parse_line/1)
+
+    %Matrix{
+      matrix: rows,
+      transposed_matrix: rows |> List.zip |> Enum.map(&Tuple.to_list/1)
+    }
+  end
+
+  defp parse_line(input_line) do
+    input_line
+    |> String.split(" ", trim: true)
+    |> Enum.map(&String.to_integer/1)
+  end
+
+  @doc """
+  Write the `matrix` out as a string, with rows separated by newlines and
+  values separated by single spaces.
+  """
+  @spec to_string(matrix :: %Matrix{}) :: String.t()
+  def to_string(%Matrix{ matrix: rows }) do
+    rows
+    |> Enum.map(&join_row/1)
+    |> Enum.join("\n")
+  end
+
+  defp join_row(row), do: Enum.join(row, " ")
+
+  @doc """
+  Given a `matrix`, return its rows as a list of lists of integers.
+  """
+  @spec rows(matrix :: %Matrix{}) :: list(list(integer))
+  def rows(%Matrix{matrix: rows}), do: rows
+
+  @doc """
+  Given a `matrix` and `index`, return the row at `index`.
+  """
+  @spec row(matrix :: %Matrix{}, index :: integer) :: list(integer)
+  def row(%Matrix{matrix: rows}, index), do: Enum.at(rows, index)
+
+  @doc """
+  Given a `matrix`, return its columns as a list of lists of integers.
+  """
+  @spec columns(matrix :: %Matrix{}) :: list(list(integer))
+  def columns(%Matrix{transposed_matrix: cols}), do: cols
+
+  @doc """
+  Given a `matrix` and `index`, return the column at `index`.
+  """
+  @spec column(matrix :: %Matrix{}, index :: integer) :: list(integer)
+  def column(%Matrix{transposed_matrix: cols}, index), do: Enum.at(cols, index)
+end
+

--- a/exercises/matrix/matrix.exs
+++ b/exercises/matrix/matrix.exs
@@ -1,0 +1,48 @@
+defmodule Matrix do
+  defstruct matrix: nil
+
+  @doc """
+  Convert an `input` string, with rows separated by newlines and values
+  separated by single spaces, into a `Matrix` struct.
+  """
+  @spec from_string(input :: String.t()) :: %Matrix{}
+  def from_string(input) do
+  end
+
+  @doc """
+  Write the `matrix` out as a string, with rows separated by newlines and
+  values separated by single spaces.
+  """
+  @spec to_string(matrix :: %Matrix{}) :: String.t()
+  def to_string(matrix) do
+  end
+
+  @doc """
+  Given a `matrix`, return its rows as a list of lists of integers.
+  """
+  @spec rows(matrix :: %Matrix{}) :: list(list(integer))
+  def rows(matrix) do
+  end
+
+  @doc """
+  Given a `matrix` and `index`, return the row at `index`.
+  """
+  @spec row(matrix :: %Matrix{}, index :: integer) :: list(integer)
+  def row(matrix, index) do
+  end
+
+  @doc """
+  Given a `matrix`, return its columns as a list of lists of integers.
+  """
+  @spec columns(matrix :: %Matrix{}) :: list(list(integer))
+  def columns(matrix) do
+  end
+
+  @doc """
+  Given a `matrix` and `index`, return the column at `index`.
+  """
+  @spec column(matrix :: %Matrix{}, index :: integer) :: list(integer)
+  def column(matrix, index) do
+  end
+end
+

--- a/exercises/matrix/matrix.exs
+++ b/exercises/matrix/matrix.exs
@@ -1,11 +1,11 @@
-defmodule Matrix do
+defmodule MatrixStruct do
   defstruct matrix: nil
 
   @doc """
   Convert an `input` string, with rows separated by newlines and values
-  separated by single spaces, into a `Matrix` struct.
+  separated by single spaces, into a `MatrixStruct` struct.
   """
-  @spec from_string(input :: String.t()) :: %Matrix{}
+  @spec from_string(input :: String.t()) :: %MatrixStruct{}
   def from_string(input) do
   end
 
@@ -13,35 +13,35 @@ defmodule Matrix do
   Write the `matrix` out as a string, with rows separated by newlines and
   values separated by single spaces.
   """
-  @spec to_string(matrix :: %Matrix{}) :: String.t()
+  @spec to_string(matrix :: %MatrixStruct{}) :: String.t()
   def to_string(matrix) do
   end
 
   @doc """
   Given a `matrix`, return its rows as a list of lists of integers.
   """
-  @spec rows(matrix :: %Matrix{}) :: list(list(integer))
+  @spec rows(matrix :: %MatrixStruct{}) :: list(list(integer))
   def rows(matrix) do
   end
 
   @doc """
   Given a `matrix` and `index`, return the row at `index`.
   """
-  @spec row(matrix :: %Matrix{}, index :: integer) :: list(integer)
+  @spec row(matrix :: %MatrixStruct{}, index :: integer) :: list(integer)
   def row(matrix, index) do
   end
 
   @doc """
   Given a `matrix`, return its columns as a list of lists of integers.
   """
-  @spec columns(matrix :: %Matrix{}) :: list(list(integer))
+  @spec columns(matrix :: %MatrixStruct{}) :: list(list(integer))
   def columns(matrix) do
   end
 
   @doc """
   Given a `matrix` and `index`, return the column at `index`.
   """
-  @spec column(matrix :: %Matrix{}, index :: integer) :: list(integer)
+  @spec column(matrix :: %MatrixStruct{}, index :: integer) :: list(integer)
   def column(matrix, index) do
   end
 end

--- a/exercises/matrix/matrix.exs
+++ b/exercises/matrix/matrix.exs
@@ -1,11 +1,11 @@
-defmodule MatrixStruct do
+defmodule Matrix do
   defstruct matrix: nil
 
   @doc """
   Convert an `input` string, with rows separated by newlines and values
-  separated by single spaces, into a `MatrixStruct` struct.
+  separated by single spaces, into a `Matrix` struct.
   """
-  @spec from_string(input :: String.t()) :: %MatrixStruct{}
+  @spec from_string(input :: String.t()) :: %Matrix{}
   def from_string(input) do
   end
 
@@ -13,35 +13,35 @@ defmodule MatrixStruct do
   Write the `matrix` out as a string, with rows separated by newlines and
   values separated by single spaces.
   """
-  @spec to_string(matrix :: %MatrixStruct{}) :: String.t()
+  @spec to_string(matrix :: %Matrix{}) :: String.t()
   def to_string(matrix) do
   end
 
   @doc """
   Given a `matrix`, return its rows as a list of lists of integers.
   """
-  @spec rows(matrix :: %MatrixStruct{}) :: list(list(integer))
+  @spec rows(matrix :: %Matrix{}) :: list(list(integer))
   def rows(matrix) do
   end
 
   @doc """
   Given a `matrix` and `index`, return the row at `index`.
   """
-  @spec row(matrix :: %MatrixStruct{}, index :: integer) :: list(integer)
+  @spec row(matrix :: %Matrix{}, index :: integer) :: list(integer)
   def row(matrix, index) do
   end
 
   @doc """
   Given a `matrix`, return its columns as a list of lists of integers.
   """
-  @spec columns(matrix :: %MatrixStruct{}) :: list(list(integer))
+  @spec columns(matrix :: %Matrix{}) :: list(list(integer))
   def columns(matrix) do
   end
 
   @doc """
   Given a `matrix` and `index`, return the column at `index`.
   """
-  @spec column(matrix :: %MatrixStruct{}, index :: integer) :: list(integer)
+  @spec column(matrix :: %Matrix{}, index :: integer) :: list(integer)
   def column(matrix, index) do
   end
 end

--- a/exercises/matrix/matrix_test.exs
+++ b/exercises/matrix/matrix_test.exs
@@ -1,0 +1,66 @@
+if !System.get_env("EXERCISM_TEST_EXAMPLES") do
+  Code.load_file("matrix.exs", __DIR__)
+end
+
+ExUnit.start
+ExUnit.configure trace: true, exclude: :pending
+
+defmodule MatrixTest do
+  use ExUnit.Case
+
+  @input "1 2 3\n4 5 6\n7 8 9"
+
+  #@tag :pending
+  test "reading from and writing to string" do
+    matrix = Matrix.from_string(@input)
+
+    assert matrix != nil
+
+    %Matrix{ matrix: parsed_matrix } = matrix
+
+    # You can represent the internal structure however you want
+    assert parsed_matrix != nil
+
+    assert Matrix.to_string(matrix) == @input
+  end
+
+  @tag :pending
+  test "rows should return nested lists regardless of internal structure" do
+    matrix = Matrix.from_string(@input)
+
+    assert Matrix.rows(matrix) == [
+      [1, 2, 3],
+      [4, 5, 6],
+      [7, 8, 9]
+    ]
+  end
+
+  @tag :pending
+  test "row should return list at index" do
+    matrix = Matrix.from_string(@input)
+
+    assert Matrix.row(matrix, 0) == [1, 2, 3]
+    assert Matrix.row(matrix, 1) == [4, 5, 6]
+    assert Matrix.row(matrix, 2) == [7, 8, 9]
+  end
+
+  @tag :pending
+  test "columns should return nested lists regardless of internal structure" do
+    matrix = Matrix.from_string(@input)
+
+    assert Matrix.columns(matrix) == [
+      [1, 4, 7],
+      [2, 5, 8],
+      [3, 6, 9]
+    ]
+  end
+
+  @tag :pending
+  test "column should return list at index" do
+    matrix = Matrix.from_string(@input)
+
+    assert Matrix.column(matrix, 0) == [1, 4, 7]
+    assert Matrix.column(matrix, 1) == [2, 5, 8]
+    assert Matrix.column(matrix, 2) == [3, 6, 9]
+  end
+end

--- a/exercises/matrix/matrix_test.exs
+++ b/exercises/matrix/matrix_test.exs
@@ -12,23 +12,23 @@ defmodule MatrixTest do
 
   #@tag :pending
   test "reading from and writing to string" do
-    matrix = Matrix.from_string(@input)
+    matrix = MatrixStruct.from_string(@input)
 
     assert matrix != nil
 
-    %Matrix{ matrix: parsed_matrix } = matrix
+    %MatrixStruct{ matrix: parsed_matrix } = matrix
 
     # You can represent the internal structure however you want
     assert parsed_matrix != nil
 
-    assert Matrix.to_string(matrix) == @input
+    assert MatrixStruct.to_string(matrix) == @input
   end
 
   @tag :pending
   test "rows should return nested lists regardless of internal structure" do
-    matrix = Matrix.from_string(@input)
+    matrix = MatrixStruct.from_string(@input)
 
-    assert Matrix.rows(matrix) == [
+    assert MatrixStruct.rows(matrix) == [
       [1, 2, 3],
       [4, 5, 6],
       [7, 8, 9]
@@ -37,18 +37,18 @@ defmodule MatrixTest do
 
   @tag :pending
   test "row should return list at index" do
-    matrix = Matrix.from_string(@input)
+    matrix = MatrixStruct.from_string(@input)
 
-    assert Matrix.row(matrix, 0) == [1, 2, 3]
-    assert Matrix.row(matrix, 1) == [4, 5, 6]
-    assert Matrix.row(matrix, 2) == [7, 8, 9]
+    assert MatrixStruct.row(matrix, 0) == [1, 2, 3]
+    assert MatrixStruct.row(matrix, 1) == [4, 5, 6]
+    assert MatrixStruct.row(matrix, 2) == [7, 8, 9]
   end
 
   @tag :pending
   test "columns should return nested lists regardless of internal structure" do
-    matrix = Matrix.from_string(@input)
+    matrix = MatrixStruct.from_string(@input)
 
-    assert Matrix.columns(matrix) == [
+    assert MatrixStruct.columns(matrix) == [
       [1, 4, 7],
       [2, 5, 8],
       [3, 6, 9]
@@ -57,10 +57,10 @@ defmodule MatrixTest do
 
   @tag :pending
   test "column should return list at index" do
-    matrix = Matrix.from_string(@input)
+    matrix = MatrixStruct.from_string(@input)
 
-    assert Matrix.column(matrix, 0) == [1, 4, 7]
-    assert Matrix.column(matrix, 1) == [2, 5, 8]
-    assert Matrix.column(matrix, 2) == [3, 6, 9]
+    assert MatrixStruct.column(matrix, 0) == [1, 4, 7]
+    assert MatrixStruct.column(matrix, 1) == [2, 5, 8]
+    assert MatrixStruct.column(matrix, 2) == [3, 6, 9]
   end
 end

--- a/exercises/matrix/matrix_test.exs
+++ b/exercises/matrix/matrix_test.exs
@@ -12,23 +12,15 @@ defmodule MatrixTest do
 
   #@tag :pending
   test "reading from and writing to string" do
-    matrix = MatrixStruct.from_string(@input)
-
-    assert matrix != nil
-
-    %MatrixStruct{ matrix: parsed_matrix } = matrix
-
-    # You can represent the internal structure however you want
-    assert parsed_matrix != nil
-
-    assert MatrixStruct.to_string(matrix) == @input
+    matrix = Matrix.from_string(@input)
+    assert Matrix.to_string(matrix) == @input
   end
 
   @tag :pending
   test "rows should return nested lists regardless of internal structure" do
-    matrix = MatrixStruct.from_string(@input)
+    matrix = Matrix.from_string(@input)
 
-    assert MatrixStruct.rows(matrix) == [
+    assert Matrix.rows(matrix) == [
       [1, 2, 3],
       [4, 5, 6],
       [7, 8, 9]
@@ -37,18 +29,18 @@ defmodule MatrixTest do
 
   @tag :pending
   test "row should return list at index" do
-    matrix = MatrixStruct.from_string(@input)
+    matrix = Matrix.from_string(@input)
 
-    assert MatrixStruct.row(matrix, 0) == [1, 2, 3]
-    assert MatrixStruct.row(matrix, 1) == [4, 5, 6]
-    assert MatrixStruct.row(matrix, 2) == [7, 8, 9]
+    assert Matrix.row(matrix, 0) == [1, 2, 3]
+    assert Matrix.row(matrix, 1) == [4, 5, 6]
+    assert Matrix.row(matrix, 2) == [7, 8, 9]
   end
 
   @tag :pending
   test "columns should return nested lists regardless of internal structure" do
-    matrix = MatrixStruct.from_string(@input)
+    matrix = Matrix.from_string(@input)
 
-    assert MatrixStruct.columns(matrix) == [
+    assert Matrix.columns(matrix) == [
       [1, 4, 7],
       [2, 5, 8],
       [3, 6, 9]
@@ -57,10 +49,10 @@ defmodule MatrixTest do
 
   @tag :pending
   test "column should return list at index" do
-    matrix = MatrixStruct.from_string(@input)
+    matrix = Matrix.from_string(@input)
 
-    assert MatrixStruct.column(matrix, 0) == [1, 4, 7]
-    assert MatrixStruct.column(matrix, 1) == [2, 5, 8]
-    assert MatrixStruct.column(matrix, 2) == [3, 6, 9]
+    assert Matrix.column(matrix, 0) == [1, 4, 7]
+    assert Matrix.column(matrix, 1) == [2, 5, 8]
+    assert Matrix.column(matrix, 2) == [3, 6, 9]
   end
 end


### PR DESCRIPTION
I wanted to use this one as an excuse to teach structs, but didn't want to tie them to using a particular internal implementation, except for when rows/columns are output, which is why the example has `matrix` and `transposed_matrix`, where the one the users see only has `matrix`, and the test just checks that it's not nil, and that `to_string` returns the same string representation as was passed in.