### PR TITLE
Update reference URL for the Hello World exercise

### DIFF
--- a/exercises/hello-world/hello_world.exs
+++ b/exercises/hello-world/hello_world.exs
@@ -15,7 +15,7 @@ defmodule HelloWorld do
   function?
 
   Hint: look into argument defaults here:
-  http://elixir-lang.org/getting-started/modules.html#default-arguments
+  http://elixir-lang.org/getting-started/modules-and-functions.html#default-arguments
   """
 
   @doc """


### PR DESCRIPTION
The current URL `http://elixir-lang.org/getting-started/modules.html#default-arguments` is outdated and users will be redirected to `http://elixir-lang.org/getting-started/modules-and-functions.html`.

This change updates the URL to point directly to the corresponding section.