### PR TITLE
Consider allowed range for first digit in area & exchange code

### DIFF
--- a/exercises/phone-number/example.exs
+++ b/exercises/phone-number/example.exs
@@ -61,7 +61,7 @@ defmodule Phone do
   "000"
   """
   @spec area_code(String.t) :: String.t
-  def area_code(raw) do         
+  def area_code(raw) do
     raw
     |> __MODULE__.number
     |> String.slice(0, 3)      # the first three digits are area_code

--- a/exercises/phone-number/phone_number.exs
+++ b/exercises/phone-number/phone_number.exs
@@ -7,11 +7,17 @@ defmodule Phone do
 
   ## Examples
 
-  iex> Phone.number("123-456-7890")
-  "1234567890"
+  iex> Phone.number("212-555-0100")
+  "2125550100"
 
-  iex> Phone.number("+1 (303) 555-1212")
-  "3035551212"
+  iex> Phone.number("+1 (212) 555-0100")
+  "2125550100"
+
+  iex> Phone.number("+1 (212) 055-0100")
+  "0000000000"
+
+  iex> Phone.number("(212) 555-0100")
+  "2125550100"
 
   iex> Phone.number("867.5309")
   "0000000000"
@@ -28,11 +34,14 @@ defmodule Phone do
 
   ## Examples
 
-  iex> Phone.area_code("123-456-7890")
-  "123"
+  iex> Phone.area_code("212-555-0100")
+  "212"
 
-  iex> Phone.area_code("+1 (303) 555-1212")
-  "303"
+  iex> Phone.area_code("+1 (212) 555-0100")
+  "212"
+
+  iex> Phone.area_code("+1 (012) 555-0100")
+  "000"
 
   iex> Phone.area_code("867.5309")
   "000"
@@ -49,8 +58,11 @@ defmodule Phone do
 
   ## Examples
 
-  iex> Phone.pretty("123-456-7890")
-  "(123) 456-7890"
+  iex> Phone.pretty("212-555-0100")
+  "(212) 555-0100"
+
+  iex> Phone.pretty("212-155-0100")
+  "(000) 000-0000"
 
   iex> Phone.pretty("+1 (303) 555-1212")
   "(303) 555-1212"

--- a/exercises/phone-number/phone_number_test.exs
+++ b/exercises/phone-number/phone_number_test.exs
@@ -9,56 +9,76 @@ defmodule PhoneTest do
   use ExUnit.Case
 
   test "cleans number" do
-    assert Phone.number("(123) 456-7890") == "1234567890"
+    assert Phone.number("(212) 555-0100") == "2125550100"
   end
 
   @tag :pending
   test "cleans number with dots" do
-    assert Phone.number("123.456.7890") == "1234567890"
+    assert Phone.number("212.555.0100") == "2125550100"
   end
 
   @tag :pending
   test "valid when 11 digits and first is 1" do
-    assert Phone.number("11234567890") == "1234567890"
+    assert Phone.number("12125550100") == "2125550100"
   end
 
   @tag :pending
-  test "invalid when 11 digits" do
-    assert Phone.number("21234567890") == "0000000000"
+  test "invalid when country calling code is not 1" do
+    assert Phone.number("22125550100") == "0000000000"
   end
 
   @tag :pending
   test "invalid when 9 digits" do
-    assert Phone.number("123456789") == "0000000000"
+    assert Phone.number("212555010") == "0000000000"
   end
 
   @tag :pending
   test "invalid when proper number of digits but letters mixed in" do
-    assert Phone.number("1a2a3a4a5a6a7a8a9a0a") == "0000000000"
+    assert Phone.number("2a1a2a5a5a5a0a1a0a0a") == "0000000000"
   end
 
   @tag :pending
   test "invalid with correct number of characters but some are letters" do
-    assert Phone.number("1a2a3a4a5a") == "0000000000"
+    assert Phone.number("2a1a2a5a5a") == "0000000000"
+  end
+
+  @tag :pending
+  test "invalid when area code begins with 1" do
+    assert Phone.number("1125550100") == "0000000000"
+  end
+
+  @tag :pending
+  test "invalid when area code begins with 0" do
+    assert Phone.number("0125550100") == "0000000000"
+  end
+
+  @tag :pending
+  test "invalid when exchange code begins with 1" do
+    assert Phone.number("2121550100") == "0000000000"
+  end
+
+  @tag :pending
+  test "invalid when exchange code begins with 0" do
+    assert Phone.number("2120550100") == "0000000000"
   end
 
   @tag :pending
   test "area code" do
-    assert Phone.area_code("1234567890") == "123"
+    assert Phone.area_code("2125550100") == "212"
   end
 
   @tag :pending
   test "area code with full US phone number" do
-    assert Phone.area_code("11234567890") == "123"
+    assert Phone.area_code("12125550100") == "212"
   end
 
   @tag :pending
   test "pretty print" do
-    assert Phone.pretty("1234567890") == "(123) 456-7890"
+    assert Phone.pretty("2125550100") == "(212) 555-0100"
   end
 
   @tag :pending
   test "pretty print with full US phone number" do
-    assert Phone.pretty("11234567890") == "(123) 456-7890"
+    assert Phone.pretty("12125550100") == "(212) 555-0100"
   end
 end

--- a/exercises/phone-number/phone_number_test.exs
+++ b/exercises/phone-number/phone_number_test.exs
@@ -23,6 +23,11 @@ defmodule PhoneTest do
   end
 
   @tag :pending
+  test "valid when 11 digits and some decorations" do
+    assert Phone.number("+1 (212) 555-0100") == "2125550100"
+  end
+
+  @tag :pending
   test "invalid when country calling code is not 1" do
     assert Phone.number("22125550100") == "0000000000"
   end


### PR DESCRIPTION
First digit in area code and exchange code should be [2-9]
Modified all the tests accordingly