### PR TITLE
Clean up Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,22 @@
 # xElixir
+
 ![build status](https://travis-ci.org/exercism/xelixir.svg?branch=master)
 
 Exercism Exercises in Elixir
 
 ## Setup
 
-The exercises currently target Elixir 1.3.2 and Erlang/OTP 19. Detailed installation instructions can be found at [http://elixir-lang.org/install.html](http://elixir-lang.org/install.html).
+The exercises currently target Elixir 1.3.2 and Erlang/OTP 19. Detailed
+installation instructions can be found at
+[http://elixir-lang.org/install.html](http://elixir-lang.org/install.html).
 
 ## Contributing
 
 Thank you so much for contributing! :tada:
 
-We welcome pull requests that provide fixes and improvements to existing exercises. If you're unsure, then go ahead and open a GitHub issue, and we'll discuss the change.
+We welcome pull requests that provide fixes and improvements to existing
+exercises. If you're unsure, then go ahead and open a GitHub issue, and we'll
+discuss the change.
 
 Please keep the following in mind:
 
@@ -19,25 +24,35 @@ Please keep the following in mind:
 
 - Pull requests should be focused on a single exercise, issue, or change.
 
-- We welcome changes to code style, and wording. Please open a separate PR for these changes if possible.
+- We welcome changes to code style, and wording. Please open a separate PR for
+  these changes if possible.
 
-- Please open an issue before creating a PR that makes significant (breaking) changes to an existing exercise or makes changes across many exercises. It is best to discuss these changes before doing the work.
+- Please open an issue before creating a PR that makes significant (breaking)
+  changes to an existing exercise or makes changes across many exercises. It is
+  best to discuss these changes before doing the work.
 
-- Follow the coding standards found in [The Elixir Style Guide](https://github.com/niftyn8/elixir_style_guide).
+- Follow the coding standards found in
+  [The Elixir Style Guide](https://github.com/niftyn8/elixir_style_guide).
 
 - Watch out for trailing spaces, extra blank lines, and spaces in blank lines.
 
-- Each exercise must stand on its own. Do not reference files outside the exercise directory. They will not be included when the user fetches the exercise.
+- Each exercise must stand on its own. Do not reference files outside the
+  exercise directory. They will not be included when the user fetches the
+  exercise.
 
-- Please do not add a README or README.md file to the exercise directory. The READMEs are constructed using shared metadata, which lives in the
-[exercism/x-common](https://github.com/exercism/x-common) repository.
+- Please do not add a README or README.md file to the exercise directory. The
+  READMEs are constructed using shared metadata, which lives in the
+  [exercism/x-common](https://github.com/exercism/x-common) repository.
 
-- Each problem should have a test suite, an example solution, and a template file for the real implementation.
-The example solution should be named `example.exs`.
+- Each problem should have a test suite, an example solution, and a template
+  file for the real implementation. The example solution should be named
+  `example.exs`.
 
 - Use typespecs in the example and template files as described [here](http://elixir-lang.org/getting-started/typespecs-and-behaviours.html).
 
-- Each test file should have code like the following at the top of the file. This allows the tests to be run on CI and configures tests to be skipped with the `:pending` flag.
+- Each test file should have code like the following at the top of the file.
+  This allows the tests to be run on CI and configures tests to be skipped with
+  the `:pending` flag.
 
 ```elixir
 if !System.get_env("EXERCISM_TEST_EXAMPLES") do
@@ -57,7 +72,9 @@ test "shouting" do
 end
 ```
 
-All the tests for xElixir exercises can be run from the top level of the repo with `$ mix test`. Please run this command before submitting your PR. Watch out for and correct any compiler warnings you may have introduced.
+All the tests for xElixir exercises can be run from the top level of the repo
+with `$ mix test`. Please run this command before submitting your PR. Watch out
+for and correct any compiler warnings you may have introduced.
 
 ## License
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -8,7 +8,6 @@ $ elixir bob_test.exs
 
 (Replace `bob_test.exs` with the name of the test file.)
 
-
 ### Pending tests
 
 In the test suites, all but the first test have been skipped.

--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,17 +1,31 @@
-[Elixir](http://elixir-lang.org/), initially released in 2012, extends upon the already robust features of Erlang while also being easier for beginners to access, read, test, and write.
+[Elixir](http://elixir-lang.org/), initially released in 2012, extends upon the
+already robust features of Erlang while also being easier for beginners to
+access, read, test, and write.
 
-José Valim, the creator of Elixir, explains [here](https://vimeo.com/53221562) how he built the language for applications to be:
+José Valim, the creator of Elixir, explains [here](https://vimeo.com/53221562)
+how he built the language for applications to be:
+
   1. Distributed
   2. Fault-Tolerant
   3. Soft-Real-Time
   4. Hot-Code-Swapped (can introduce new code without stopping the server)
 
-Elixir actually compiles down to [bytecode](https://en.wikipedia.org/wiki/Bytecode) and then runs on the [BEAM Erlang Virtual Machine](http://erlangcentral.org/videos/euc-2014-robert-virding-hitchhikers-tour-of-the-beam/).
+Elixir actually compiles down to [bytecode](https://en.wikipedia.org/wiki/Bytecode)
+and then runs on the [BEAM Erlang Virtual Machine](http://erlangcentral.org/videos/euc-2014-robert-virding-hitchhikers-tour-of-the-beam/).
 
-There is no "conversion cost" for calling Erlang, meaning you can run Erlang code right next to Elixir code.
+There is no "conversion cost" for calling Erlang, meaning you can run Erlang
+code right next to Elixir code.
 
-Being a functional language, everything in Elixir is an expression. Elixir has "First Class Documentation" meaning comments  can be attached to a function, making it easier to retrieve. Regular expressions are also given first class treatment, removing awkward escaping within strings.
+Being a functional language, everything in Elixir is an expression. Elixir has
+"First Class Documentation" meaning comments  can be attached to a function,
+making it easier to retrieve. Regular expressions are also given first class
+treatment, removing awkward escaping within strings.
 
-Elixir's asynchronous communication implementation allows the code to be lightweight, yet incorporate high-volume concurrency. Programmers use Elixir to handle thousands of requests and responses *concurrently* on a single server node. It has been used successfully for microservices that need to consume and serve a multitude of APIs rapidly.
+Elixir's asynchronous communication implementation allows the code to be
+lightweight, yet incorporate high-volume concurrency. Programmers use Elixir to
+handle thousands of requests and responses *concurrently* on a single server
+node. It has been used successfully for microservices that need to consume and
+serve a multitude of APIs rapidly.
 
-The [Phoenix framework](http://www.phoenixframework.org/) helps structure Elixir applications for the web.  
+The [Phoenix framework](http://www.phoenixframework.org/) helps structure Elixir
+applications for the web.

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -1,4 +1,6 @@
-Exercism provides exercises and feedback but can be difficult to jump into for those learning Elixir for the first time. These resources can help you get started:
+Exercism provides exercises and feedback but can be difficult to jump into for
+those learning Elixir for the first time. These resources can help you get
+started:
 
 * [Elixir Getting Started Guide](http://elixir-lang.org/getting-started/introduction.html)
 * [Elixir Documentation](http://elixir-lang.org/docs/stable/elixir/)

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -3,7 +3,7 @@
 * [Elixir Docs](http://elixir-lang.org/docs.html)
 
 ## Hex - A package manager for the Erlang ecosystem.
-  
+
 * [Hex Docs](https://hex.pm/)
 
 ## Testing with ExUnit

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -8,7 +8,6 @@ $ elixir bob_test.exs
 
 (Replace `bob_test.exs` with the name of the test file.)
 
-
 ### Pending tests
 
 In the test suites, all but the first test have been skipped.
@@ -74,7 +73,6 @@ If this is the first time you have run Dialyzer you
 will most likely not have a `plt` file. The persistent lookup table,
 or PLT is used by Dialyzer to cache information about built in Elixir
 and Erlang types. To create a plt with sensible defaults run:
-
 
 ```bash
 $ dialyzer --build_plt --apps erts kernel stdlib crypto public_key /path/to/elixir


### PR DESCRIPTION
This commit intends to "clean up" some formatting issues in the Markdown files:

- It limits lines to 80 characters, except when a link is simply too long. Some people read these files in a terminal.
- Remove useless whitespace. This includes consecutive blank lines.
- Add blank lines around headers and code blocks.

These changes don't change the look of rendered pages.